### PR TITLE
Socket.ping() should be idempotent, if not race conditions can appear and connection closes.

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -97,12 +97,13 @@ Socket.prototype.onError = function (err) {
  */
 
 Socket.prototype.ping = function () {
-  clearTimeout(this.pingTimeoutTimer);
+  clearTimeout(this.pingIntervalTimer);
 
   var self = this;
   this.pingIntervalTimer = setTimeout(function () {
     debug('writing ping packet - expected pong in %sms', self.server.pingTimeout);
     self.sendPacket('ping');
+    clearTimeout(self.pingTimeoutTimer);
     self.pingTimeoutTimer = setTimeout(function () {
       self.onClose('ping timeout');
     }, self.server.pingTimeout);


### PR DESCRIPTION
I have the following transports allowed :
polling, websocket

You have several code paths that call Socket.ping(), and if called twice in a row
one timeout is left dangling, closing connection while pongs are still being properly received.

This commit ensures idempotency !
