### PR TITLE
add on('error') handler for websocket transport

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -155,7 +155,7 @@ Server.prototype.handleRequest = function (req, res) {
   }
 
   if (req.query.sid) {
-    debug('seting new request for existing client');
+    debug('setting new request for existing client');
     this.clients[req.query.sid].transport.onRequest(req);
   } else {
     this.handshake(req.query.transport, req);

--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -25,6 +25,7 @@ function WebSocket (socket) {
   this.socket = socket;
   this.socket.on('message', this.onData.bind(this));
   this.socket.once('close', this.onClose.bind(this));
+  this.socket.on('error', this.onError.bind(this));
   this.writable = true;
 };
 


### PR DESCRIPTION
if an error is happening on the `websocket.io` socket, this socket emits an error. since the current engine.io socket is not handling this error, the whole process crashes.

a simple binding seems to resolve this issue.

_example of a log output_

```
node.js:201
        throw e; // process.nextTick error, or 'error' event on first tick
              ^
Error: read ETIMEDOUT
    at errnoException (net.js:642:11)
    at TCP.onread (net.js:375:20)
----------------------------------------
    at EventEmitter.on
    at WebSocket.Socket (/.../node_modules/engine.ns.io/node_modules/engine.io/node_modules/websocket.io/lib/socket.js:30:6)
    at new WebSocket (/.../node_modules/engine.ns.io/node_modules/engine.io/node_modules/websocket.io/lib/protocols/hybi-07-12.js:61:10)
    at Server.createClient (/.../node_modules/engine.ns.io/node_modules/engine.io/node_modules/websocket.io/lib/server.js:88:10)
    at Server.handleUpgrade (/.../node_modules/engine.ns.io/node_modules/engine.io/node_modules/websocket.io/lib/server.js:60:21)
    at Server.handleUpgrade (/.../node_modules/engine.ns.io/node_modules/engine.io/lib/server.js:208:11)
    at Server.<anonymous> (/.../node_modules/engine.ns.io/node_modules/engine.io/lib/engine.io.js:126:16)
    at Server.emit (events.js:88:20)
----------------------------------------
    at EventEmitter.on
    at Object.attach (/.../node_modules/engine.ns.io/node_modules/engine.io/lib/engine.io.js:124:12)
    at Object.listen (/.../node_modules/engine.ns.io/node_modules/engine.io/lib/engine.io.js:80:24)
    at Object.<anonymous> (/.../server.coffee:269:17)
    at Object.<anonymous> (/.../server.coffee:278:4)
    at Module._compile (module.js:441:26)
    at Object.run (/.../node_modules/coffee-script/lib/coffee-script/coffee-script.js:68:25)
    at /.../node_modules/coffee-script/lib/coffee-script/command.js:135:29
    at /.../node_modules/coffee-script/lib/coffee-script/command.js:110:18
```
