### PR TITLE
Fix POST content type for Firefox. 

### DIFF
--- a/lib/transports/polling.js
+++ b/lib/transports/polling.js
@@ -138,7 +138,7 @@ Polling.prototype.onDataRequest = function (req, res) {
 
     function onEnd () {
       self.onData(chunks);
-      res.writeHead(200, self.headers(req, { 'Content-Length': 2 }));
+      res.writeHead(200, self.headers(req, { 'Content-Length': 2, 'Content-Type': 'text/plain; charset=UTF-8' }));
       res.end('ok');
       cleanup();
     };
@@ -153,7 +153,7 @@ Polling.prototype.onDataRequest = function (req, res) {
 
 /**
  * Processes the incoming data payload.
- * 
+ *
  * @param {String} encoded payload
  * @api private
  */


### PR DESCRIPTION
Same as https://github.com/LearnBoost/socket.io/pull/806 but for Engine.io
