### PR TITLE
fix calling .close() during a socket upgrade

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -228,7 +228,7 @@ Server.prototype.onWebSocket = function (socket) {
   var req = socket.req
     , id = req.query.sid
 
-  if (id && typeof this.clients[id] !== 'undefined') {
+  if (id && this.clients[id]) {
     if (this.clients[id].upgraded) {
       debug('transport had already been upgraded');
       socket.close();

--- a/test/server.js
+++ b/test/server.js
@@ -358,6 +358,15 @@ describe('server', function () {
         });
       });
     });
+    it('should abort upgrade if socket is closed (#35)', function (done) {
+      var engine = listen({ allowUpgrades: true }, function (port) {
+        var socket = new eioc.Socket('ws://localhost:%d'.s(port));
+        socket.on('open', function () {
+          socket.close();
+          done();
+        });
+      });
+    });
   });
 
   describe('messages', function () {


### PR DESCRIPTION
Calling server.close() immediately after connecting a client throws this error

```
TypeError: Cannot read property 'upgraded' of undefined
      at Server.onWebSocket (/home/contra/Projects/protosock/node_modules/engine.io/lib/server.js:233:25)
      at Server.EventEmitter.emit (events.js:88:17)
      at WebSocket.Server.handleUpgrade (/home/contra/Projects/protosock/node_modules/engine.io/node_modules/websocket.io/lib/server.js:84:10)
      at WebSocket.EventEmitter.emit (events.js:85:17)
      at WebSocket.onOpen (/home/contra/Projects/protosock/node_modules/engine.io/node_modules/websocket.io/lib/protocols/hybi.js:87:14)
      at process.startup.processNextTick.process._tickCallback (node.js:244:9)
```

There is probably a better place to fix this
