### PR TITLE
avoid new id clash with existing clients' ids

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -119,7 +119,12 @@ Server.prototype.prepare = function (req) {
  */
 
 Server.prototype.id = function () {
-  return String(Math.random() * Math.random()).substr(3);
+  while (true)
+  {
+    var id = String(Math.random() * Math.random()).substr(3);
+    if (!this.clients.hasOwnProperty(id)) // make sure we create an id not yet used by anyone
+      return id;
+  }
 };
 
 /**


### PR DESCRIPTION
with many simultaneous clients, in very rare cases, ids will clash if not checked
