### PR TITLE
Expose same httpServer for .attach as for .listen

### DIFF
--- a/lib/engine.io.js
+++ b/lib/engine.io.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -149,6 +148,8 @@ exports.attach = function (server, options) {
       engine.handleSocket(socket);
     });
   }
+  
+  engine.httpServer = server;
 
   return engine;
 };


### PR DESCRIPTION
When an engine.io instance is created using `listen`, its httpServer is exposed using the `httpServer` property. This same property should be exposed for instances created using `attach` as well, for libraries that need access to the underlying engine http server.
