### PR TITLE
Make some classes overridable

### DIFF
--- a/lib/engine.io.js
+++ b/lib/engine.io.js
@@ -94,8 +94,9 @@ exports.listen = function (port, options, fn) {
  */
 
 exports.attach = function (server, options) {
-  var engine = new exports.Server(options)
-    , options = options || {}
+  options || (options = {});
+  var Server = options.serverClass || exports.Server;
+  var engine = new Server(options)
     , path = (options.path || '/engine.io').replace(/\/$/, '')
     , resource = options.resource || 'default'
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -37,6 +37,7 @@ function Server (opts) {
   this.transports = opts.transports || Object.keys(transports);
   this.allowUpgrades = false !== opts.allowUpgrades;
   this.cookie = false !== opts.cookie ? (opts.cookie || 'io') : false;
+  this.socketClass = opts.socketClass || Socket;
 
   // initialize websocket server
   if (~this.transports.indexOf('websocket')) {
@@ -185,6 +186,7 @@ Server.prototype.handshake = function (transport, req) {
   debug('handshaking client "%d"', id);
 
   var transport = new transports[transport](req)
+    , Socket = this.socketClass
     , socket = new Socket(id, this, transport)
     , self = this
 


### PR DESCRIPTION
I am extending engine.io with my own library, [oil](https://github.com/carlos8f/engine.oil), and I need to pass in my own server and socket classes which extend engine's. Is this agreeable?
