### PR TITLE
Reduce per-request overhead by not sending default values

### DIFF
--- a/lib/transports/polling-jsonp.js
+++ b/lib/transports/polling-jsonp.js
@@ -57,10 +57,13 @@ JSONP.prototype.doWrite = function (data) {
   data = this.head + JSON.stringify(data) + this.foot;
 
   var headers = {
-      'Content-Type': 'text/javascript; charset=UTF-8'
+      'Content-Type': 'text/javascript'
     , 'Content-Length': Buffer.byteLength(data)
-    , 'Connection': 'Keep-Alive'
   };
+
+  if (this.req.httpVersion !== '1.1') { // Keep-Alive is the default in HTTP 1.1
+    headers.Connection = 'Keep-Alive';
+  }
 
   this.res.writeHead(200, this.headers(this.req, headers));
   this.res.end(data);

--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -38,8 +38,11 @@ XHR.prototype.doWrite = function (data) {
   var headers = {
       'Content-Type': 'text/plain; charset=UTF-8'
     , 'Content-Length': Buffer.byteLength(data)
-    , 'Connection': 'Keep-Alive'
   };
+
+  if (this.req.httpVersion !== '1.1') { // Keep-Alive is the default in HTTP 1.1
+    headers.Connection = 'Keep-Alive';
+  }
 
   this.res.writeHead(200, this.headers(this.req, headers));
   this.res.end(data);


### PR DESCRIPTION
'Keep-Alive' is the default connection mode in HTTP 1.1. Quoting RFC 2616:

> 8.1.2 Overall Operation
> 
> A significant difference between HTTP/1.1 and earlier versions of HTTP is that persistent connections are the default behavior of any HTTP connection. That is, unless otherwise indicated, the client SHOULD assume that the server will maintain a persistent connection, even after error responses from the server. 

'UTF-8' is the default character set for JSON. Quoting RFC 4627:

> 1.  Encoding
>    
>    JSON text SHALL be encoded in Unicode.  The default encoding is UTF-8.

I propose this change for the polling transports, as they incur the HTTP header overhead on every request
