### PR TITLE
Document that toString() is performed on the message argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ A representation of a client. _Inherits from EventEmitter_.
 - `message`
     - Fired when the client sends a message.
     - **Arguments**
-      - `String`: utf-8 string
+      - `String`: unicode string
 - `error`
     - Fired when an error occurs.
     - **Arguments**
@@ -245,9 +245,9 @@ A representation of a client. _Inherits from EventEmitter_.
 ##### Methods
 
 - `send`:
-    - Sends a message.
+    - Sends a message, performing `message = toString(arguments[0])`.
     - **Parameters**
-      - `String`: utf-8 string with outgoing data
+      - `String`: a string or any object implementing `toString()`, with outgoing data
     - **Returns** `Socket` for chaining
 - `close`
     - Disconnects the client


### PR DESCRIPTION
This is what engine.io in fact already (implicitly) does, so I can give it any object I want, and it will send what `message.toString()` returns.

This allows me to implement transparent caching of the JSONified string, speeding up broadcast and multicast messages.
