### PR TITLE
directly load the parser module

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,6 +1,5 @@
-
 /**
  * Exposes the client parser to avoid code repetition.
  */
 
-module.exports = require('engine.io-client').parser;
+module.exports = require('engine.io-client/lib/parser');


### PR DESCRIPTION
I have to problems with `module.exports = require('engine.io-client').parser;`
1. It loads more than is needed
2. It loads the JSONP transport client, which creates a global
