### PR TITLE
Slow upgrade should not take down server.

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -149,7 +149,7 @@ Socket.prototype.maybeUpgrade = function (transport) {
   var checkInterval;
   var upgradeTimeout = setTimeout(function () {
     debug('client did not complete upgrade - closing transport');
-    clearInteval(checkInterval);
+    clearInterval(checkInterval);
     if ('open' == transport.readyState) {
       transport.close();
     }


### PR DESCRIPTION
I noticed this on very heavily overloaded server - the typos raises an uncaught exception.
