### PR TITLE
optional pong payload

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -34,6 +34,7 @@ function Server(opts){
   opts = opts || {};
   this.pingTimeout = opts.pingTimeout || 60000;
   this.pingInterval = opts.pingInterval || 25000;
+  this.pongPayload = opts.pongPayload || false;
   this.upgradeTimeout = opts.upgradeTimeout || 10000;
   this.transports = opts.transports || Object.keys(transports);
   this.allowUpgrades = false !== opts.allowUpgrades;

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -80,7 +80,7 @@ Socket.prototype.onPacket = function (packet) {
 
       case 'ping':
         debug('got ping');
-        this.sendPacket('pong');
+        this.sendPacket('pong', this.server.pongPayload ? JSON.stringify(this.server.pongPayload) : '');
         this.emit('heartbeat');
         this.setPingTimeout();
         break;


### PR DESCRIPTION
Goes together with: LearnBoost/engine.io-client#58

We need this to identify the server instance with each ping so client can re-connect if server instance changed (between long-polling requests).
