### PR TITLE
FAILING mass data test

### DIFF
--- a/test/server.js
+++ b/test/server.js
@@ -735,7 +735,6 @@ describe('server', function () {
         });
         var socket = new eioc.Socket('ws://localhost:%d'.s(port), { transports: ['websocket'] });
         socket.on('open', function () {
-console.log("should receive", messageCount);            
           for (var i=0;i<messageCount;i++) {
 //            connection.send('message: ' + i);   // works
             connection.send(messagePayload + '|message: ' + i);   // does not work
@@ -743,7 +742,6 @@ console.log("should receive", messageCount);
           var receivedCount = 0;
           socket.on('message', function (msg) {
             receivedCount += 1;
-console.log("received", receivedCount);            
             if (receivedCount === messageCount) {
               done();
             }


### PR DESCRIPTION
This is a failing test to cover sending of lots of data via websocket transport.

I cannot figure out what the exact problem is. I think it is in the `ws` layer.

Once this is solved there are more cases to test:
- Other transports
- Sending lots of data right after `engine.on('connection')` (instead of after client `socket.on('open')` which this test covers).
