### PR TITLE
Socket.flush: reset writeBuffer before send

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -293,8 +293,9 @@ Socket.prototype.flush = function () {
     debug('flushing buffer to transport');
     this.emit('flush', this.writeBuffer);
     this.server.emit('flush', this, this.writeBuffer);
-    this.transport.send(this.writeBuffer);
+    var wbuf = this.writeBuffer;
     this.writeBuffer = [];
+    this.transport.send(wbuf);
     this.emit('drain');
     this.server.emit('drain', this);
   }


### PR DESCRIPTION
This prevents legacy node versions from calling Socket.flush before it
could reset writeBuffer, leading to double-flush.
