### PR TITLE
server: send validation failure reason to clients

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -46,6 +46,22 @@ function Server(opts){
 };
 
 /**
+ * Protocol errors mappings.
+ */
+
+Server.errors = {
+  UNKNOWN_TRANSPORT: 0,
+  UNKNOWN_SID: 1,
+  BAD_HANDSHAKE_METHOD: 2
+};
+
+Server.errorMessages = {
+  0: 'Transport unknown',
+  1: 'Session ID unknown',
+  2: 'Bad handshake method'
+};
+
+/**
  * Inherits from EventEmitter.
  */
 
@@ -84,15 +100,17 @@ Server.prototype.verify = function(req){
   var transport = req.query.transport;
   if (!~this.transports.indexOf(transport)) {
     debug('unknown transport "%s"', transport);
-    return false;
+    return Server.errors.UNKNOWN_TRANSPORT;
   }
 
   // sid check
   if (req.query.sid) {
-    return this.clients.hasOwnProperty(req.query.sid);
+    return this.clients.hasOwnProperty(req.query.sid) ||
+           Server.errors.UNKNOWN_SID;
   } else {
     // handshake is GET only
-    return 'GET' == req.method;
+    return 'GET' == req.method ||
+           Server.errors.BAD_HANDSHAKE_METHOD;
   }
 
   return true;
@@ -138,9 +156,13 @@ Server.prototype.handleRequest = function(req, res){
   this.prepare(req);
   req.res = res;
 
-  if (!this.verify(req)) {
-    res.writeHead(500);
-    res.end();
+  var code = this.verify(req);
+  if (code !== true) {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      code: code,
+      message: Server.errorMessages[code]
+    }));
     return this;
   }
 
@@ -198,7 +220,7 @@ Server.prototype.handshake = function(transport, req){
 Server.prototype.handleUpgrade = function(req, socket, head){
   this.prepare(req);
 
-  if (!this.verify(req)) {
+  if (this.verify(req) !== true) {
     socket.end();
     return;
   }

--- a/test/engine.io.js
+++ b/test/engine.io.js
@@ -49,7 +49,9 @@ describe('engine', function () {
       server.listen(function () {
         var uri = 'http://localhost:%d/engine.io/default/'.s(server.address().port);
         request.get(uri, function (res) {
-          expect(res.status).to.be(500);
+          expect(res.status).to.be(400);
+          expect(res.body.code).to.be(0);
+          expect(res.body.message).to.be('Transport unknown');
           server.once('close', done);
           server.close();
         });
@@ -188,7 +190,9 @@ describe('engine', function () {
       server.listen(function () {
         var port = server.address().port;
         request.get('http://localhost:%d/engine.io/default/'.s(port), function (res) {
-          expect(res.status).to.be(500);
+          expect(res.status).to.be(400);
+          expect(res.body.code).to.be(0);
+          expect(res.body.message).to.be('Transport unknown');
           request.get('http://localhost:%d/test'.s(port), function (res) {
             expect(res.status).to.be(200);
             expect(listeners).to.eql(2);

--- a/test/server.js
+++ b/test/server.js
@@ -20,7 +20,9 @@ describe('server', function () {
         request.get('http://localhost:%d/engine.io/default/'.s(port))
           .query({ transport: 'tobi' }) // no tobi transport - outrageous
           .end(function (res) {
-            expect(res.status).to.be(500);
+            expect(res.status).to.be(400);
+            expect(res.body.code).to.be(0);
+            expect(res.body.message).to.be('Transport unknown');
             done();
           });
       });
@@ -32,7 +34,9 @@ describe('server', function () {
         request.get('http://localhost:%d/engine.io/default/'.s(port))
           .query({ transport: 'constructor' })
           .end(function (res) {
-            expect(res.status).to.be(500);
+            expect(res.status).to.be(400);
+            expect(res.body.code).to.be(0);
+            expect(res.body.message).to.be('Transport unknown');
             done();
           });
       });
@@ -43,7 +47,9 @@ describe('server', function () {
         request.get('http://localhost:%d/engine.io/default/'.s(port))
           .query({ transport: 'polling', sid: 'test' })
           .end(function (res) {
-            expect(res.status).to.be(500);
+            expect(res.status).to.be(400);
+            expect(res.body.code).to.be(1);
+            expect(res.body.message).to.be('Session ID unknown');
             done();
           });
       });


### PR DESCRIPTION
Make 400 a validation failure http code, and send JSON payload with error reason to clients.

I'm not sure if encoding body with JSON is the best option here, any comments would be welcome
