### PR TITLE
Fixed packet send callback issues

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -247,6 +247,13 @@ Socket.prototype.setupSendCallback = function () {
       if ('function' == typeof seqFn) {
         debug('executing send callback');
         seqFn(self.transport);
+      } else if (Array.isArray(seqFn)) {
+        debug('executing batch send callback');
+        for (var i in seqFn) {
+          if ('function' == typeof seqFn) {
+            seqFn[i](self.transport);
+          }
+        }
       }
     }
   });
@@ -288,9 +295,8 @@ Socket.prototype.sendPacket = function (type, data, callback) {
     this.writeBuffer.push(packet);
 
     //add send callback to object
-    if (callback) {
-      this.packetsFn.push(callback);
-    }
+    this.packetsFn.push(callback);
+
     this.flush();
   }
 };
@@ -309,6 +315,9 @@ Socket.prototype.flush = function () {
     this.server.emit('flush', this, this.writeBuffer);
     var wbuf = this.writeBuffer;
     this.writeBuffer = [];
+    if (!this.transport.supportsFraming) {
+      this.packetsFn = [this.packetsFn];
+    }
     this.transport.send(wbuf);
     this.emit('drain');
     this.server.emit('drain', this);

--- a/lib/transports/flashsocket.js
+++ b/lib/transports/flashsocket.js
@@ -37,6 +37,14 @@ FlashSocket.prototype.__proto__ = WebSocket.prototype;
 FlashSocket.prototype.name = 'flashsocket';
 
 /**
+ * Advertise framing support.
+ *
+ * @api public
+ */
+
+FlashSocket.prototype.supportsFraming = true;
+
+/**
  * Listens for new configuration changes of the Manager
  * this way we can enable and disable the flash server.
  *

--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -56,6 +56,14 @@ WebSocket.prototype.name = 'websocket';
 WebSocket.prototype.handlesUpgrades = true;
 
 /**
+ * Advertise framing support.
+ *
+ * @api public
+ */
+
+WebSocket.prototype.supportsFraming = true;
+
+/**
  * Processes the incoming data.
  *
  * @param {String} encoded packet


### PR DESCRIPTION
There were two issues here.
1. When Socket.send called with or without callback alternately, the trigger order is incorrect.
2. The 'drain' event from transport is one per packet for transports supporting framing like websocket and is all in one for those without framing like polling.
