### PR TITLE
Improve Transport and Socket reliability

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -103,7 +103,7 @@ Socket.prototype.onPacket = function (packet) {
         break;
     }
   } else {
-    debug('packet received with closed socket');
+    debug('packet received with non-open socket');
   }
 };
 
@@ -189,10 +189,10 @@ Socket.prototype.maybeUpgrade = function (transport) {
       debug('got upgrade packet - upgrading');
       self.upgraded = true;
       self.emit('upgrade', transport);
+      self.flush();
       self.clearTransport();
       self.setTransport(transport);
       self.setPingTimeout();
-      self.flush();
       clearInterval(checkInterval);
       clearTimeout(upgradeTimeout);
       transport.removeListener('packet', onPacket);
@@ -210,26 +210,37 @@ Socket.prototype.maybeUpgrade = function (transport) {
  */
 
 Socket.prototype.clearTransport = function () {
+  // For polling, transport's error event doesn't necessarily imply a close event
+  // It's now safe to close() multiple times, and only first time onClose counts
+  //   as readyStatus already changed
+  // The overhead is one more close packet to send for non-connection errors
+  // Note that it's possible that Socket readyState is 'closed'
+  //   and Transport readyState is 'closing' because onClose called
+  //   only after close packet sent for polling
+  this.transport.close();
+  // Don't receive any events from this transport any longer
+  //   to avoid confusion for upgrade
+  this.transport.removeAllListeners();
   // silence further transport errors and prevent uncaught exceptions
   this.transport.on('error', function(){
     debug('error triggered by discarded transport');
   });
-  clearTimeout(this.pingIntervalTimer);
   clearTimeout(this.pingTimeoutTimer);
 };
 
 /**
  * Called upon transport considered closed.
- * Possible reasons: `ping timeout`, `client error`, `parse error`,
- * `transport error`, `server close`, `transport close`
+ * Possible reasons: `ping timeout`, `parse error`,
+ * `transport error`, `transport close`, `forced close`
  */
 
 Socket.prototype.onClose = function (reason, description) {
   if ('closed' != this.readyState) {
+    // keep out others
+    this.readyState = 'closed';
     this.packetsFn = [];
     this.sentCallbackFn = [];
     this.clearTransport();
-    this.readyState = 'closed';
     this.emit('close', reason, description);
   }
 };

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -61,6 +61,13 @@ Transport.prototype.onRequest = function (req) {
  */
 
 Transport.prototype.close = function (fn) {
+  if ('closed' === this.readyState) {
+    if ('function' == typeof fn) {
+      fn();
+    }
+    return;
+  }
+
   this.readyState = 'closing';
   this.doClose(fn || noop);
 };

--- a/lib/transports/polling.js
+++ b/lib/transports/polling.js
@@ -49,6 +49,16 @@ Polling.prototype.name = 'polling';
 Polling.prototype.onRequest = function (req) {
   var res = req.res;
 
+  if ('closed' === this.readyState) {
+    /* This should be handled in the upper layer of the stack */
+    debug('incoming request after transport closed');
+    return false;
+  }
+
+  if ('opening' === this.readyState) {
+    this.readyState = 'open';
+  }
+
   if ('GET' == req.method) {
     this.onPollRequest(req, res);
   } else if ('POST' == req.method) {
@@ -71,6 +81,7 @@ Polling.prototype.onPollRequest = function (req, res) {
     // assert: this.res, '.req and .res should be (un)set together'
     this.onError('overlap from client');
     res.writeHead(500);
+    res.end();
   } else {
     debug('setting request');
     if (undefined === this.req) {
@@ -84,12 +95,14 @@ Polling.prototype.onPollRequest = function (req, res) {
     var self = this;
 
     function onClose () {
+      cleanup();
       self.onError('poll connection closed prematurely');
     }
 
     function cleanup () {
       req.removeListener('close', onClose);
       self.req = self.res = null;
+      self.writable = false;
     }
 
     req.cleanup = cleanup;
@@ -117,6 +130,7 @@ Polling.prototype.onDataRequest = function (req, res) {
     // assert: this.dataRes, '.dataReq and .dataRes should be (un)set together'
     this.onError('data request overlap from client');
     res.writeHead(500);
+    res.end();
   } else {
     this.dataReq = req;
     this.dataRes = res;
@@ -174,6 +188,7 @@ Polling.prototype.onData = function (data) {
   for (var i = 0, l = packets.length; i < l; i++) {
     if ('close' == packets[i].type) {
       debug('got xhr close packet');
+      this.req && this.req.cleanup();
       return this.onClose();
     }
 
@@ -189,14 +204,28 @@ Polling.prototype.onData = function (data) {
  */
 
 Polling.prototype.send = function (packets) {
+  if (!this.writable || 'closed' === this.readyState) {
+    /* it's more like a bug to reach here */
+    debug('send while closed or not writable');
+    return false;
+  }
+
   if (this.shouldClose) {
     debug('appending close packet to payload');
     packets.push({ type: 'close' });
-    this.shouldClose();
-    this.shouldClose = null;
   }
 
   this.write(parser.encodePayload(packets));
+
+  if (this.shouldClose) {
+    for (var i in this.shouldClose) {
+      if ('function' == typeof this.shouldClose[i]) {
+        this.shouldClose[i]();
+      }
+    }
+    this.shouldClose = null;
+    this.onClose();
+  }
 };
 
 /**
@@ -210,7 +239,6 @@ Polling.prototype.write = function (data) {
   debug('writing "%s"', data);
   this.doWrite(data);
   this.req.cleanup();
-  this.writable = false;
 };
 
 /**
@@ -228,12 +256,15 @@ Polling.prototype.doClose = function (fn) {
     this.dataReq.abort();
   }
 
+  if (!this.shouldClose) {
+    this.shouldClose = [];
+  }
+  this.shouldClose.push(fn);
+
   if (this.writable) {
     debug('transport writable - closing right away');
     this.send([{ type: 'close' }]);
-    fn();
   } else {
     debug('transport not writable - buffering orderly close');
-    this.shouldClose = fn;
   }
 };

--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -117,5 +117,6 @@ WebSocket.prototype.send = function (data){
 WebSocket.prototype.doClose = function (fn) {
   debug('closing');
   this.socket.close();
+  this.writable = false;
   fn && fn();
 };


### PR DESCRIPTION
1. Add a new Transport readyState 'open' used in handling upgrade
2. Make Transport close safe to call multiple times
3. Reliable close event and cleanup for polling transport
4. Disable writable since closing for websocket
5. Fix issues while upgrading
6. Clean up some comments and debug logs
7. Always close Transport when Socket closes
