### PR TITLE
close socket if upgrade is received and socket.readyState != open

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -185,7 +185,7 @@ Socket.prototype.maybeUpgrade = function (transport) {
       }
 
       checkInterval = setInterval(check, 100);
-    } else if ('upgrade' == packet.type) {
+    } else if ('upgrade' == packet.type && self.readyState == 'open') {
       debug('got upgrade packet - upgrading');
       self.upgraded = true;
       self.emit('upgrade', transport);


### PR DESCRIPTION
if a socket is closed (`socket.close()`) while an upgrade is happening, i.e. after the server received the `ping` (probe) and sent his own `pong` (probe), but before he received the `upgrade` packet, and the old, polling socket is currently not writable (i.e. the `close` packet was not sent), the `ws` transport stays open and both client and server, but no data is sent through it since the eio server's socket is on `closed`.

by calling a `transport.close` if an upgrade is received on any readyState but `open`, the race condition does not occur anymore in our tests.
