### PR TITLE
Add Version Badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Engine.IO: the realtime engine
 
 [![Build Status](https://secure.travis-ci.org/LearnBoost/engine.io.png)](http://travis-ci.org/LearnBoost/engine.io)
+[![NPM version](https://badge.fury.io/js/engine.io.png)](http://badge.fury.io/js/engine.io)
 
 `Engine` is the implementation of transport-based cross-browser/cross-device
 bi-directional communication layer for


### PR DESCRIPTION
As discussed with @guille, I'm adding the Version Badge to the README.  This should help existing users and new visitors to the Github page to find out about the existence and version of the module.
