### PR TITLE
Clear all timers on socket clos

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -226,6 +226,9 @@ Socket.prototype.clearTransport = function () {
 
 Socket.prototype.onClose = function (reason, description) {
   if ('closed' != this.readyState) {
+    clearTimeout(this.pingTimeoutTimer);
+    clearInterval(this.checkIntervalTimer);
+    clearTimeout(this.upgradeTimeoutTimer);
     var self = this;
     // clean writeBuffer in next tick, so developers can still
     // grab the writeBuffer on 'close' event


### PR DESCRIPTION
If you do not do this then programs don't exit cleanly when you close open engine.io sockets. This is annoying for writing tests which you expect to close cleanly once you teardown the engine.io server
