### PR TITLE
Bump ws dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     ]
   , "dependencies": {
         "debug": "0.6.0"
-      , "ws": "0.4.25"
+      , "ws": "0.4.27"
       , "engine.io-parser": "0.3.0"
       , "base64id": "0.1.0"
     }


### PR DESCRIPTION
ws 0.4.27 includes a number of fixes for node 0.10.x.
