### PR TITLE
Fixed tests. Closes #184 and #185

### DIFF
--- a/test/engine.io.js
+++ b/test/engine.io.js
@@ -59,7 +59,7 @@ describe('engine', function () {
     });
 
     it('should respond to flash policy requests', function (done) {
-      var server = http.createServer()
+      var server = net.createServer({allowHalfOpen: true})
         , engine = eio.attach(server);
 
       server.listen(function () {


### PR DESCRIPTION
The response it not sent due to the connection not allowing half-open connections. This should address #184.
The end event is not received due to a missing data handler. This should address #185.
