### PR TITLE
Make connections sticky to a node instance behind the LB

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -38,6 +38,7 @@ function Server(opts){
   this.transports = opts.transports || Object.keys(transports);
   this.allowUpgrades = false !== opts.allowUpgrades;
   this.cookie = false !== opts.cookie ? (opts.cookie || 'io') : false;
+  this.workerId = opts.workerId || 0;
 
   // initialize websocket server
   if (~this.transports.indexOf('websocket')) {

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -59,6 +59,7 @@ Socket.prototype.onOpen = function () {
   this.transport.sid = this.id;
   this.sendPacket('open', JSON.stringify({
       sid: this.id
+    , wid: this.server.workerId
     , upgrades: this.getAvailableUpgrades()
     , pingInterval: this.server.pingInterval
     , pingTimeout: this.server.pingTimeout


### PR DESCRIPTION
Load balancers can use worker id to target a specific node instance behind the LB. Just add a workerId option like this:

``` js
var io = eio.attach(httpServer, {workerId: cluster.worker.id});
```

See also LearnBoost/engine.io-client#220
