### PR TITLE
adding support to cross domain custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ to a single process.
       - `cookie` (`String|Boolean`): name of the HTTP cookie that
         contains the client sid to send as part of handshake response
         headers. Set to `false` to not send one. (`io`)
+      - `enableCorsCustomHeaders` (`Boolean`): should the server honor
+        custom headers in a cross domain scenario (`false`)
 - `close`
     - Closes all clients
     - **Returns** `Server` for chaining

--- a/lib/server.js
+++ b/lib/server.js
@@ -38,6 +38,7 @@ function Server(opts){
   this.transports = opts.transports || Object.keys(transports);
   this.allowUpgrades = false !== opts.allowUpgrades;
   this.cookie = false !== opts.cookie ? (opts.cookie || 'io') : false;
+  this.enableCorsCustomHeaders = true === opts.enableCorsCustomHeaders;
 
   // initialize websocket server
   if (~this.transports.indexOf('websocket')) {
@@ -157,6 +158,16 @@ Server.prototype.handleRequest = function(req, res){
   debug('handling "%s" http request "%s"', req.method, req.url);
   this.prepare(req);
   req.res = res;
+
+  if (this.enableCorsCustomHeaders && req.method == 'OPTIONS') {
+    res.setHeader('Access-Control-Allow-Origin', req.headers.origin);
+    res.setHeader('Access-Control-Allow-Methods', req.headers['access-control-request-method']);
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+    res.setHeader('Access-Control-Allow-Headers', req.headers['access-control-request-headers']);
+    res.writeHead(204);
+    res.end();
+    return this;
+  }
 
   var code = this.verify(req);
   if (code !== true) {


### PR DESCRIPTION
To support this client side feature: https://github.com/LearnBoost/engine.io-client/pull/216
No effect on code that does not need this feature.
