### PR TITLE
Fix possible DOS and small changes to timeouts

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -26,6 +26,10 @@ function Socket (id, server, transport, req) {
   this.packetsFn = [];
   this.sentCallbackFn = [];
   this.request = req;
+  
+  this.checkIntervalTimer = null;
+  this.upgradeTimeoutTimer = null;
+  this.pingTimeoutTimer = null;
 
   this.setTransport(transport);
   this.onOpen();
@@ -158,6 +162,7 @@ Socket.prototype.maybeUpgrade = function (transport) {
   self.upgradeTimeoutTimer = setTimeout(function () {
     debug('client did not complete upgrade - closing transport');
     clearInterval(self.checkIntervalTimer);
+    self.checkIntervalTimer = null;
     if ('open' == transport.readyState) {
       transport.close();
     }
@@ -166,6 +171,7 @@ Socket.prototype.maybeUpgrade = function (transport) {
   function onPacket(packet){
     if ('ping' == packet.type && 'probe' == packet.data) {
       transport.send([{ type: 'pong', data: 'probe' }]);
+      clearInterval(self.checkIntervalTimer);
       self.checkIntervalTimer = setInterval(check, 100);
     } else if ('upgrade' == packet.type && self.readyState == 'open') {
       debug('got upgrade packet - upgrading');
@@ -176,6 +182,7 @@ Socket.prototype.maybeUpgrade = function (transport) {
       self.setPingTimeout();
       self.flush();
       clearInterval(self.checkIntervalTimer);
+      self.checkIntervalTimer = null;
       clearTimeout(self.upgradeTimeoutTimer);
       transport.removeListener('packet', onPacket);
     } else {
@@ -219,6 +226,7 @@ Socket.prototype.onClose = function (reason, description) {
   if ('closed' != this.readyState) {
     clearTimeout(this.pingTimeoutTimer);
     clearInterval(this.checkIntervalTimer);
+    this.checkIntervalTimer = null;
     clearTimeout(this.upgradeTimeoutTimer);
     var self = this;
     // clean writeBuffer in next tick, so developers can still


### PR DESCRIPTION
By sending many upgrade event a client could possible create a lot of intervals without the old ones having a chance of being cleared. I also added the intervals to the constructor and made it use setImmediate instead of process.nextTick.
