### PR TITLE
removed flashpolicy request handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,6 @@ These are exposed by `require('engine.io')`:
       - `Object`: optional, options object
     - **Options**
       - `path` (`String`): name of the path to capture (`/engine.io`).
-      - `policyFile` (`Boolean`): whether to handle policy file requests (`true`)
       - `destroyUpgrade` (`Boolean`): destroy unhandled upgrade requests (`true`)
       - `destroyUpgradeTimeout` (`Number`): milliseconds after which unhandled requests are ended (`1000`)
       - **See Server options below for additional options you can pass**
@@ -196,12 +195,6 @@ to a single process.
       - `http.ServerRequest`: a node request object
       - `net.Stream`: TCP socket for the request
       - `Buffer`: legacy tail bytes
-    - **Returns** `Server` for chaining
-- `handleSocket`
-    - Called with raw TCP sockets from http requests to intercept flash policy
-      file requests
-    - **Parameters**
-      - `net.Stream`: TCP socket on which requests are listened
     - **Returns** `Server` for chaining
 
 <hr><br>
@@ -269,7 +262,7 @@ A representation of a client. _Inherits from EventEmitter_.
 Exposed in the `eio` global namespace (in the browser), or by
 `require('engine.io-client')` (in Node.JS).
 
-For the client API refer to the 
+For the client API refer to the
 [engine-client](http://github.com/learnboost/engine.io-client) repository.
 
 ## Debug / logging
@@ -377,7 +370,7 @@ WebSocket/FlashSocket based connections have two fundamental benefits:
       they all need to be routed to the process and computer that owns the `Engine`
       connection. This negatively impacts RAM and CPU usage.
   - _B: Network traffic_<br>
-      WebSocket is designed around the premise that each message frame has to be 
+      WebSocket is designed around the premise that each message frame has to be
       surrounded by the least amount of data. In HTTP 1.1 transports, each message
       frame is surrounded by HTTP headers and chunked encoding frames. If you try to
       send the message _"Hello world"_ with xhr-polling, the message ultimately
@@ -411,7 +404,7 @@ proven problematic:
 3. **Cloud application platforms**<br>
     Platforms like Heroku or No.de have had trouble keeping up with the fast-paced
     nature of the evolution of the WebSocket protocol. Applications therefore end up
-    inevitably using long polling, but the seamless installation experience of 
+    inevitably using long polling, but the seamless installation experience of
     Socket.IO we strive for (_"require() it and it just works"_) disappears.
 
 Some of these problems have solutions. In the case of proxies and personal programs,
@@ -453,7 +446,7 @@ safely lazy load it without hurting user experience), etc.
 ### Can I use engine without Socket.IO ?
 
 Absolutely. Although the recommended framework for building realtime applications
-is Socket.IO, since it provides fundamental features for real-world applications 
+is Socket.IO, since it provides fundamental features for real-world applications
 such as multiplexing, reconnection support, etc.
 
 `Engine` is to Socket.IO what Connect is to Express. An essential piece for building
@@ -482,7 +475,7 @@ to look at the file in the appropriate git branch/tag.
 The Java/NIO implementation will be officially supported, and is being worked
 on by the author.
 
-## License 
+## License
 
 (The MIT License)
 

--- a/lib/engine.io.js
+++ b/lib/engine.io.js
@@ -142,14 +142,5 @@ exports.attach = function (server, options) {
     });
   }
 
-  // flash policy file
-  var trns = engine.transports;
-  var policy = options.policyFile;
-  if (~trns.indexOf('flashsocket') && false !== policy) {
-    server.on('connection', function (socket) {
-      engine.handleSocket(socket);
-    });
-  }
-
   return engine;
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -288,26 +288,3 @@ Server.prototype.onWebSocket = function(req, socket){
     this.handshake(req.query.transport, req);
   }
 };
-
-/**
- * Handles a regular connection to watch for flash policy requests.
- *
- * @param {net.Stream} socket
- * @api private
- */
-
-var policy = readFileSync(__dirname + '/transports/flashsocket.xml');
-
-Server.prototype.handleSocket = function(socket){
-  socket.on('data', function onData(data){
-    // no need for buffering as node will discard subsequent packets
-    // since they constitute a malformed HTTP request
-    if (60 == data[0] && 23 == data.length) {
-      var str = data.slice(0, 23).toString();
-      if ('<policy-file-request/>\0' == str) {
-        socket.end(policy);
-      }
-    }
-    socket.removeListener('data', onData);
-  });
-};

--- a/lib/transports/flashsocket.js
+++ b/lib/transports/flashsocket.js
@@ -17,7 +17,7 @@ module.exports = FlashSocket;
  * @param {http.ServerRequest} request
  * @api public
  */
- 
+
 function FlashSocket (req) {
   WebSocket.call(this, req);
 }
@@ -43,66 +43,3 @@ FlashSocket.prototype.name = 'flashsocket';
  */
 
 FlashSocket.prototype.supportsFraming = true;
-
-/**
- * Listens for new configuration changes of the Manager
- * this way we can enable and disable the flash server.
- *
- * @param {Manager} Manager instance.
- * @api private
- */
-
-FlashSocket.init = function (manager) {
-  var server;
-  function create () {
-    server = require('policyfile').createServer({ 
-      log: function(msg){
-        manager.log.info(msg.toLowerCase());
-      }
-    }, manager.get('origins'));
-
-    server.on('close', function (e) {
-      server = null;
-    });
-
-    server.listen(manager.get('flash policy port'), manager.server);
-
-    manager.flashPolicyServer = server;
-  }
-
-  // listen for origin changes, so we can update the server
-  manager.on('set:origins', function (value, key) {
-    if (!server) return;
-
-    // update the origins and compile a new response buffer
-    server.origins = Array.isArray(value) ? value : [value];
-    server.compile();
-  });
-
-  // destory the server and create a new server
-  manager.on('set:flash policy port', function (value, key) {
-    var transports = manager.get('transports');
-    if (~transports.indexOf('flashsocket')) {
-      if (server) {
-        if (server.port === value) return;
-        // destroy the server and rebuild it on a new port
-        try {
-          server.close();
-        }
-        catch (e) { /* ignore exception. could e.g. be that the server isn't started yet */ }
-      }
-      create();
-    }
-  });
-
-  // only start the server
-  manager.on('set:transports', function (value, key){
-    if (!server && ~manager.get('transports').indexOf('flashsocket')) {
-      create();
-    }
-  });
-  // check if we need to initialize at start
-  if (~manager.get('transports').indexOf('flashsocket')){
-    create();
-  }
-};

--- a/lib/transports/flashsocket.xml
+++ b/lib/transports/flashsocket.xml
@@ -1,1 +1,0 @@
-<?xml version="1.0"?><!DOCTYPE cross-domain-policy SYSTEM "http://www.macromedia.com/xml/dtds/cross-domain-policy.dtd"><cross-domain-policy><allow-access-from domain="*" to-ports="*"/></cross-domain-policy>

--- a/test/engine.io.js
+++ b/test/engine.io.js
@@ -61,67 +61,6 @@ describe('engine', function () {
       });
     });
 
-    it('should respond to flash policy requests', function (done) {
-      var server = net.createServer({allowHalfOpen: true})
-        , engine = eio.attach(server);
-
-      server.listen(function () {
-        var client = net.createConnection(server.address().port);
-        client.write('<policy-file-request/>\0');
-        client.setEncoding('ascii');
-        client.on('data', function (data) {
-          expect(data).to.contain('<allow-access-from');
-          client.end();
-          done();
-        });
-      });
-    });
-
-    it('should not respond to borked flash policy requests', function (done) {
-      var server = http.createServer()
-        , engine = eio.attach(server);
-
-      server.listen(function () {
-        var client = net.createConnection(server.address().port);
-        client.write('<policy-file-req>\0');
-        client.setEncoding('ascii');
-        client.on('data', function () {
-          done(new Error('Should not respond'));
-        });
-        setTimeout(done, 20);
-      });
-    });
-
-    it('should not respond to flash policy requests when policyFile:false', function (done) {
-      var server = http.createServer()
-        , engine = eio.attach(server, { policyFile: false });
-
-      server.listen(function () {
-        var client = net.createConnection(server.address().port);
-        client.write('<policy-file-req>\0');
-        client.setEncoding('ascii');
-        client.on('data', function (data) {
-          done(new Error('Should not fire'));
-        });
-        setTimeout(done, 20);
-      });
-    });
-
-    it('should not respond to flash policy requests when no flashsocket', function (done) {
-      var server = http.createServer()
-        , engine = eio.attach(server, { transports: ['xhr-polling', 'websocket'] });
-
-      server.listen(function () {
-        var client = net.createConnection(server.address().port);
-        client.write('<policy-file-req>\0');
-        client.setEncoding('ascii');
-        client.on('data', function (data) {
-          done(new Error('Should not fire'));
-        });
-        setTimeout(done, 20);
-      });
-    });
-
     it('should destroy upgrades not handled by engine', function (done) {
       var server = http.createServer()
         , engine = eio.attach(server);


### PR DESCRIPTION
Open for discussion...

This pull request removes all flash policy handling from engine.io
- Client should have the option to specify policy server
- Removes obsolete code from lib/transports/flashsocket.js

Related:
Engile.io-client pull request - https://github.com/LearnBoost/engine.io-client/pull/258
