### PR TITLE
close() properly when triggered in connection handler

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -233,12 +233,13 @@ Server.prototype.handshake = function(transport, req){
 
   this.clients[id] = socket;
   this.clientsCount++;
-  this.emit('connection', socket);
 
   socket.once('close', function(){
     delete self.clients[id];
     self.clientsCount--;
   });
+
+  this.emit('connection', socket);
 };
 
 /**


### PR DESCRIPTION
Addresses issue #225. Memory leak, yes, but more an edge case based on how init code was ordered.
