### PR TITLE
Added support for user-level query params to socket.request

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -135,6 +135,14 @@ Server.prototype.prepare = function(req){
   if (!req._query) {
     req._query = ~req.url.indexOf('?') ? qs.parse(parse(req.url).query) : {};
   }
+
+  // remove lib-specific query params for user
+  req.query = {};
+  for (var i in req._query) {
+    if ('transport' != i && 'EIO' != i && 'sid' != i) {
+      req.query[i] = req._query[i];
+    }
+  }
 };
 
 /**


### PR DESCRIPTION
Socket.request.query should be usable for auth, etc now.

Clones the request._query object but removes the library specific keys.
