### PR TITLE
Newline escape fix

### DIFF
--- a/lib/transports/polling-jsonp.js
+++ b/lib/transports/polling-jsonp.js
@@ -5,6 +5,8 @@
 
 var Polling = require('./polling');
 var qs = require('querystring');
+var rDoubleSlashes = /\\\\n/g;
+var rSlashes = /(\\)?\\n/g;
 
 /**
  * Module exports.
@@ -43,7 +45,12 @@ JSONP.prototype.onData = function (data) {
   // and the fast alternative to decodeURIComponent
   data = qs.parse(data).d;
   if ('string' == typeof data) {
-    Polling.prototype.onData.call(this, data.replace(/\\n/g, '\n'));
+    //client will send already escaped newlines as \\\\n and newlines as \\n
+    // \\n must be replaced with \n and \\\\n with \\n
+    data = data.replace(rSlashes, function(match, slashes) {
+      return slashes ? match : '\n';
+    });
+    Polling.prototype.onData.call(this, data.replace(rDoubleSlashes, '\\n'));
   }
 };
 

--- a/test/jsonp.js
+++ b/test/jsonp.js
@@ -96,43 +96,74 @@ describe('JSONP', function () {
   });
 
   describe('messages', function () {
-    it('should arrive from client to server and back (pollingJSONP)', function (done) {
-      var engine = listen( { allowUpgrades: false, transports: ['polling'] }, function (port) {
-        var socket = new eioc.Socket('ws://localhost:' + port
+    var engine, port, socket;
+
+    beforeEach(function(done) {
+      engine = listen( { allowUpgrades: false, transports: ['polling'] }, function (p) {
+        port = p;
+
+        socket = new eioc.Socket('ws://localhost:' + port
           , { transports: ['polling'], forceJSONP: true, upgrade: false });
-        engine.on('connection', function (conn) {
-          conn.on('message', function (msg) {
-            conn.send('a');
-          });
+
+        done();
+      });
+    });
+
+    it('should arrive from client to server and back (pollingJSONP)', function (done) {
+      engine.on('connection', function (conn) {
+        conn.on('message', function (msg) {
+          conn.send('a');
         });
-        socket.on('open', function () {
-          socket.send('a');
-          socket.on('message', function (msg) {
-            expect(socket.transport.query.j).to.not.be(undefined);
-            expect(msg).to.be('a');
-            done();
-          });
+      });
+
+      socket.on('open', function () {
+        socket.send('a');
+        socket.on('message', function (msg) {
+          expect(socket.transport.query.j).to.not.be(undefined);
+          expect(msg).to.be('a');
+          done();
         });
+      });
+    });
+
+    it('should not fail JSON.parse for stringified messages', function (done) {
+      engine.on('connection', function(conn) {
+        conn.on('message', function(message) {
+          expect(JSON.parse(message)).to.be.eql({test : 'a\r\nb\n\n\n\nc'});
+          done();
+        });
+      });
+      socket.on('open', function () {
+        socket.send(JSON.stringify({test : 'a\r\nb\n\n\n\nc'}));
+      });
+    });
+
+    it('should parse newlines in message correctly', function (done) {
+      engine.on('connection', function(conn) {
+        conn.on('message', function(message) {
+          expect(message).to.be.equal('a\r\nb\n\n\n\nc');
+          done();
+        });
+      });
+      socket.on('open', function () {
+        socket.send('a\r\nb\n\n\n\nc');
       });
     });
 
     it('should arrive from server to client and back with binary data (pollingJSONP)', function(done) {
       var binaryData = new Buffer(5);
       for (var i = 0; i < 5; i++) binaryData[i] = i;
-      var engine = listen( { allowUpgrades: false, transports: ['polling'] }, function (port) {
-        var socket = new eioc.Socket('ws://localhost:' + port, { transports: ['polling'], forceJSONP: true, upgrade: false});
-        engine.on('connection', function (conn) {
-          conn.on('message', function (msg) {
-            conn.send(msg);
-          });
+      engine.on('connection', function (conn) {
+        conn.on('message', function (msg) {
+          conn.send(msg);
         });
+      });
 
-        socket.on('open', function() {
-          socket.send(binaryData);
-          socket.on('message', function (msg) {
-            for (var i = 0; i < msg.length; i++) expect(msg[i]).to.be(i);
-            done();
-          });
+      socket.on('open', function() {
+        socket.send(binaryData);
+        socket.on('message', function (msg) {
+          for (var i = 0; i < msg.length; i++) expect(msg[i]).to.be(i);
+          done();
         });
       });
     });


### PR DESCRIPTION
If message contained escaped newline(sent as \\\\n) then String.replace would result in \\\n when the actual result should be \\n, any json message would fail to parse
