### PR TITLE
Bump version number for patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "engine.io",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "The realtime engine behind Socket.IO. Provides the foundation of a bidirectional connection between client and server",
   "main": "./lib/engine.io",
   "author": "Guillermo Rauch <guillermo@learnboost.com>",


### PR DESCRIPTION
Related to Automattic@816fd2e that bumped the `engine.io-parser` version. The version of engine.io on npm hasn't been bumped yet for this change.
