### PR TITLE
port https memory leak fix from socket.io

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -195,13 +195,17 @@ Server.prototype.handshake = function(transport, req){
  * @api public
  */
 
-Server.prototype.handleUpgrade = function(req, socket, head){
+Server.prototype.handleUpgrade = function(req, socket, upgradeHead){
   this.prepare(req);
 
   if (!this.verify(req)) {
     socket.end();
     return;
   }
+
+  var head = new Buffer(upgradeHead.length);
+  upgradeHead.copy(head);
+  upgradeHead = null;
 
   // delegate to ws
   var self = this;


### PR DESCRIPTION
https://github.com/Automattic/socket.io/issues/1177 still exists in engine.io

This PR applies https://github.com/Automattic/socket.io/pull/1143 to engine.io
