### PR TITLE
Cache remote address in handshake since it might be lost later.

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -26,7 +26,10 @@ function Socket (id, server, transport, req) {
   this.packetsFn = [];
   this.sentCallbackFn = [];
   this.request = req;
-  
+
+  // Cache IP since it might not be in the req later
+  this.remoteAddress = req.connection.remoteAddress;
+
   this.checkIntervalTimer = null;
   this.upgradeTimeoutTimer = null;
   this.pingTimeoutTimer = null;


### PR DESCRIPTION
For the Socket.IO handshake address property.
