### PR TITLE
Fix for #281

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -197,13 +197,7 @@ Server.prototype.handleRequest = function(req, res){
  function sendErrorMessage(req, res, code) {
     var headers = { 'Content-Type': 'application/json' };
 
-    if (req.headers.origin) {
-      headers['Access-Control-Allow-Credentials'] = 'true';
-      headers['Access-Control-Allow-Origin'] = req.headers.origin;
-    } else {
-      headers['Access-Control-Allow-Origin'] = '*';
-    }
-    res.writeHead(400, headers);
+    res.writeHead(403, headers);
     res.end(JSON.stringify({
       code: code,
       message: Server.errorMessages[code]


### PR DESCRIPTION
Send 403 Forbidden instead of 400 Bad Request as more logical response code

Not set CORS headers when origin in fact is not allowed to access
