### PR TITLE
socket: allow upgrades if the socket is still in closing state (courtesy of @3rd-Eden)

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -176,7 +176,7 @@ Socket.prototype.maybeUpgrade = function (transport) {
       transport.send([{ type: 'pong', data: 'probe' }]);
       clearInterval(self.checkIntervalTimer);
       self.checkIntervalTimer = setInterval(check, 100);
-    } else if ('upgrade' == packet.type && self.readyState == 'open') {
+    } else if ('upgrade' == packet.type && self.readyState != 'closed') {
       debug('got upgrade packet - upgrading');
       self.upgraded = true;
       self.clearTransport();
@@ -188,6 +188,11 @@ Socket.prototype.maybeUpgrade = function (transport) {
       self.checkIntervalTimer = null;
       clearTimeout(self.upgradeTimeoutTimer);
       transport.removeListener('packet', onPacket);
+      if (self.readyState == 'closing') {
+        transport.close(function () {
+          self.onClose('forced close');
+        });
+      }
     } else {
       transport.close();
     }


### PR DESCRIPTION
This ensures that any buffered data still to be flushed, can be sent to the client.
After flushing the data, if the `readyState` was set to `'closing'`, this will close the newly created transport and the connection.
