### PR TITLE
Add iframe onload handling to jsonp tests.

### DIFF
--- a/test/jsonp.js
+++ b/test/jsonp.js
@@ -61,6 +61,13 @@ describe('JSONP', function () {
           self.areaValue = data;
         });
         return textarea;
+      } else if (~name.indexOf('iframe')) {
+        var iframe = {};
+        setTimeout(function() {
+          if (iframe.onload) iframe.onload();
+        }, 0);
+
+        return iframe;
       } else {
         return {};
       }


### PR DESCRIPTION
`onload` handling required for the `drain` event to fire. We need this
for some tests that look at socket closing.
