### PR TITLE
polling: close the pending poll request when closing transport

### DIFF
--- a/lib/transports/polling.js
+++ b/lib/transports/polling.js
@@ -207,6 +207,20 @@ Polling.prototype.onData = function (data) {
 };
 
 /**
+ * Overrides onClose.
+ *
+ * @api private
+ */
+
+Polling.prototype.onClose = function () {
+  if (this.writable) {
+    // close pending poll request
+    this.send([{ type: 'noop' }]);
+  }
+  Transport.prototype.onClose.call(this);
+};
+
+/**
  * Writes a packet payload.
  *
  * @param {Object} packet


### PR DESCRIPTION
This ensures that the poll request is not left open.

The following example shows the issue.

``` js
var Socket = require('engine.io-client');
var server = require('http').createServer();
var eio = require('engine.io').attach(server);

eio.on('connection', function (socket) {
  socket.on('close', function () {
    console.log('Y U NO EXIT (屮ಠ益ಠ)屮');
    server.close(function () {
      console.log('bye');
    });
  });
});

server.listen(3000, function () {
  var socket = new Socket('http://localhost:3000/', {
    transports: ['polling']
  });

  socket.on('open', function () {
    setTimeout(function () {
      socket.close();
    }, 0);
  });
});
```

A pending poll request prevents the server from being closed. The `close` event is never emitted and the process does not exit.
