### PR TITLE
socket: flush the write buffer before closing the socket (fixes #293)

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -370,11 +370,24 @@ Socket.prototype.getAvailableUpgrades = function () {
  */
 
 Socket.prototype.close = function () {
-  if ('open' == this.readyState) {
-    this.readyState = 'closing';
-    var self = this;
-    this.transport.close(function () {
-      self.onClose('forced close');
-    });
+  if ('open' != this.readyState) return;
+
+  this.readyState = 'closing';
+
+  if (this.writeBuffer.length) {
+    this.once('drain', this.closeTransport.bind(this));
+    return;
   }
+
+  this.closeTransport();
+};
+
+/**
+ * Closes the underlying transport.
+ *
+ * @api private
+ */
+
+Socket.prototype.closeTransport = function () {
+  this.transport.close(this.onClose.bind(this, 'forced close'));
 };

--- a/test/server.js
+++ b/test/server.js
@@ -903,7 +903,7 @@ describe('server', function () {
       });
     });
 
-    it('should arrive from server to client (ws)', function (done) {
+    it('should arrive from server to client (multiple, ws)', function (done) {
       var opts = { allowUpgrades: false, transports: ['websocket'] };
       var engine = listen(opts, function (port) {
         var socket = new eioc.Socket('ws://localhost:%d'.s(port), { transports: ['websocket'] })
@@ -925,6 +925,34 @@ describe('server', function () {
               done();
             }, 50);
           });
+        });
+
+        socket.on('open', function () {
+          socket.on('message', function (msg) {
+            expect(msg).to.be(expected[i++]);
+          });
+        });
+      });
+    });
+
+    it('should arrive from server to client (multiple, no delay, ws)', function (done) {
+      var opts = { allowUpgrades: false, transports: ['websocket'] };
+      var engine = listen(opts, function (port) {
+        var socket = new eioc.Socket('ws://localhost:%d'.s(port), { transports: ['websocket'] })
+          , expected = ['a', 'b', 'c']
+          , i = 0;
+
+        engine.on('connection', function (conn) {
+          conn.on('close', function () {
+            setTimeout(function () {
+              expect(i).to.be(3);
+              done();
+            }, 50);
+          });
+          conn.send('a');
+          conn.send('b');
+          conn.send('c');
+          conn.close();
         });
 
         socket.on('open', function () {


### PR DESCRIPTION
This ensures that all the packets in the `writeBuffer` are sent to the transport before trying to close it.

**Note:** it is totally possible that the `close` method is called when the transport is still executing its `send` method, see [here](https://github.com/Automattic/engine.io/blob/0cc7cdfe6cbe4167e1df7081b8f9312344e7723f/lib/transports/websocket.js#L87-L97). In this case the socket is closed anyway and remaining messages will not have their callback executed due to [this](https://github.com/Automattic/engine.io/blob/0cc7cdfe6cbe4167e1df7081b8f9312344e7723f/lib/socket.js#L245) cleanup.
I don't know if it is better to refactor the WebSocket `send` method and defer the `close` invocation.
