### PR TITLE
CHANGELOG: fix attributions

### DIFF
--- a/History.md
+++ b/History.md
@@ -16,8 +16,8 @@
 ==================
 
  * package: bump `ws` to fix fd leaks
- * socket: flush the write buffer before closing the socket [nkzawa]
- * polling: close the pending poll request when closing transport [nkzawa]
+ * socket: flush the write buffer before closing the socket [lpinca]
+ * polling: close the pending poll request when closing transport [lpinca]
 
 1.4.2 / 2014-10-08
 ==================


### PR DESCRIPTION
Both 1d8e0743988ee4aa5851104f7a5661536ed7f5d6 and e754f7eb231f74f6d831392d8248f2326adca1a5 are my commits.