### PR TITLE
Set encoding of the request to utf8 before listening on data events

### DIFF
--- a/lib/transports/polling.js
+++ b/lib/transports/polling.js
@@ -177,9 +177,9 @@ Polling.prototype.onDataRequest = function (req, res) {
   }
 
   req.on('close', onClose);
+  if (!isBinary) req.setEncoding('utf8');
   req.on('data', onData);
   req.on('end', onEnd);
-  if (!isBinary) req.setEncoding('utf8');
 };
 
 /**


### PR DESCRIPTION
Hello,

I'm running into a case where the data event handler is called before the set encoding is called, in this case I end up having `chunks` as an empty string and `data` is a Buffer thus raising the error `Possibly unhandled TypeError: Object has no method 'copy'
I always thought the data event handler was called after the next tick, but it does not seem to be the case, or I am missing something.
Moving the setEncoding method before attaching the handler resolves my issue.

Thank