### PR TITLE
Cookie path

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,9 @@ to a single process.
       - `cookie` (`String|Boolean`): name of the HTTP cookie that
         contains the client sid to send as part of handshake response
         headers. Set to `false` to not send one. (`io`)
+      - `cookiePath` (`String|Boolean`): path of the above `cookie`
+        option. If false, no path will be sent, which means browsers will only send the cookie on the engine.io attached path (`/engine.io`).
+        Set this to `/` to send the io cookie on all requests. (`false`)
 - `close`
     - Closes all clients
     - **Returns** `Server` for chaining
@@ -318,7 +321,7 @@ A representation of a client. _Inherits from EventEmitter_.
 Exposed in the `eio` global namespace (in the browser), or by
 `require('engine.io-client')` (in Node.JS).
 
-For the client API refer to the 
+For the client API refer to the
 [engine-client](http://github.com/learnboost/engine.io-client) repository.
 
 ## Debug / logging
@@ -397,7 +400,7 @@ WebSocket based connections have two fundamental benefits:
       they all need to be routed to the process and computer that owns the `Engine`
       connection. This negatively impacts RAM and CPU usage.
   - _B: Network traffic_<br>
-      WebSocket is designed around the premise that each message frame has to be 
+      WebSocket is designed around the premise that each message frame has to be
       surrounded by the least amount of data. In HTTP 1.1 transports, each message
       frame is surrounded by HTTP headers and chunked encoding frames. If you try to
       send the message _"Hello world"_ with xhr-polling, the message ultimately
@@ -431,7 +434,7 @@ proven problematic:
 3. **Cloud application platforms**<br>
     Platforms like Heroku or No.de have had trouble keeping up with the fast-paced
     nature of the evolution of the WebSocket protocol. Applications therefore end up
-    inevitably using long polling, but the seamless installation experience of 
+    inevitably using long polling, but the seamless installation experience of
     Socket.IO we strive for (_"require() it and it just works"_) disappears.
 
 Some of these problems have solutions. In the case of proxies and personal programs,
@@ -473,7 +476,7 @@ safely lazy load it without hurting user experience), etc.
 ### Can I use engine without Socket.IO ?
 
 Absolutely. Although the recommended framework for building realtime applications
-is Socket.IO, since it provides fundamental features for real-world applications 
+is Socket.IO, since it provides fundamental features for real-world applications
 such as multiplexing, reconnection support, etc.
 
 `Engine` is to Socket.IO what Connect is to Express. An essential piece for building
@@ -498,7 +501,7 @@ Absolutely. The [engine.io-protocol](https://github.com/LearnBoost/engine.io-pro
 repository contains the most up to date description of the specification
 at all times, and the parser implementation in JavaScript.
 
-## License 
+## License
 
 (The MIT License)
 
@@ -522,4 +525,3 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-

--- a/lib/server.js
+++ b/lib/server.js
@@ -44,7 +44,7 @@ function Server(opts){
   this.allowUpgrades = false !== opts.allowUpgrades;
   this.allowRequest = opts.allowRequest;
   this.cookie = false !== opts.cookie ? (opts.cookie || 'io') : false;
-  this.cookiePath = false;
+  this.cookiePath = false !== opts.cookiePath ? (opts.cookiePath || false) : false;
   this.perMessageDeflate = false !== opts.perMessageDeflate ? (opts.perMessageDeflate || true) : false;
   this.httpCompression = false !== opts.httpCompression ? (opts.httpCompression || {}) : false;
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -44,6 +44,7 @@ function Server(opts){
   this.allowUpgrades = false !== opts.allowUpgrades;
   this.allowRequest = opts.allowRequest;
   this.cookie = false !== opts.cookie ? (opts.cookie || 'io') : false;
+  this.cookiePath = false;
   this.perMessageDeflate = false !== opts.perMessageDeflate ? (opts.perMessageDeflate || true) : false;
   this.httpCompression = false !== opts.httpCompression ? (opts.httpCompression || {}) : false;
 
@@ -257,7 +258,11 @@ Server.prototype.handshake = function(transport, req){
 
   if (false !== this.cookie) {
     transport.on('headers', function(headers){
-      headers['Set-Cookie'] = self.cookie + '=' + id;
+      var cookie = self.cookie + '=' + id;
+      if(false !== self.cookiePath) {
+        cookie += '; path=' + self.cookiePath;
+      }
+      headers['Set-Cookie'] = cookie;
     });
   }
 

--- a/test/server.js
+++ b/test/server.js
@@ -95,6 +95,18 @@ describe('server', function () {
       });
     });
 
+    it('should send the cookie with custom path', function (done) {
+      var engine = listen({ cookiePath: '/' }, function (port) {
+        request.get('http://localhost:%d/engine.io/default/'.s(port))
+          .query({ transport: 'polling', b64: 1 })
+          .end(function (res) {
+            var sid = res.text.match(/"sid":"([^"]+)"/)[1];
+            expect(res.headers['set-cookie'][0]).to.be('io=' + sid + '; path=/');
+            done();
+          });
+      });
+    });
+
     it('should not send the io cookie', function (done) {
       var engine = listen({ cookie: false }, function (port) {
         request.get('http://localhost:%d/engine.io/default/'.s(port))


### PR DESCRIPTION
Added `cookiePath` option to allow setting the path of the `io` cookie. Before, no path was set (which is also the default now). No path implicitly means the io cookie will be sent by browsers only on the path on which it was set, eg `/engine.io`.

Can be set to `/` now to get the id of the connected socket on subsequent non-io requests to the server.