### PR TITLE
remove X-XSS-Protection header defined in polling-jsonp because it's overridden anyway

### DIFF
--- a/lib/transports/polling-jsonp.js
+++ b/lib/transports/polling-jsonp.js
@@ -84,11 +84,6 @@ JSONP.prototype.doWrite = function (data, options, callback) {
 JSONP.prototype.headers = function (req, headers) {
   headers = headers || {};
 
-  // disable XSS protection for IE
-  if (/MSIE 8\.0/.test(req.headers['user-agent'])) {
-    headers['X-XSS-Protection'] = '0';
-  }
-
   this.emit('headers', headers);
   return headers;
 };

--- a/test/server.js
+++ b/test/server.js
@@ -2198,4 +2198,31 @@ describe('server', function () {
       testForTransport('polling', done);
     });
   });
+
+  describe('response headers', function () {
+    function testForHeaders(headers, done) {
+      var engine = listen(function (port) {
+        var socket = new eioc.Socket('ws://localhost:%d'.s(port), {
+          extraHeaders: headers,
+          transports: ['polling']
+        });
+        engine.on('connection', function (conn) {
+          expect(conn.request.res._header).to.contain('X-XSS-Protection: 0');
+          done();
+        });
+        socket.on('open', function () {});
+      });
+    }
+
+    it('should contain X-XSS-Protection: 0 for IE8', function (done) {
+      var headers = { 'user-agent': 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; Tablet PC 2.0)' };
+      testForHeaders(headers, done);
+    });
+
+    it('should contain X-XSS-Protection: 0 for IE11', function (done) {
+      var headers = { 'user-agent': 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko' };
+      testForHeaders(headers, done);
+    });
+  });
+
 });


### PR DESCRIPTION
X-XSS-Protection header definition in polling-jsonp is dead because it's overridden in https://github.com/Automattic/engine.io/blob/master/lib/transports/polling.js#L177 anyway.

this is also confusing because in polling-jsonp the header is added only for IE8, but in polling it is added for IE9-11 as well as IE8.
it's better to remove the polling-jsonp part.

i added a few tests to make sure it's ok.
