### PR TITLE
Fixes socket.io#1910 by calling transport.close() on ping timeout

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -127,6 +127,7 @@ Socket.prototype.setPingTimeout = function () {
   var self = this;
   clearTimeout(self.pingTimeoutTimer);
   self.pingTimeoutTimer = setTimeout(function () {
+    self.transport.close();
     self.onClose('ping timeout');
   }, self.server.pingInterval + self.server.pingTimeout);
 };


### PR DESCRIPTION
There have been a few of us struggling with socketio/socket.io#1910. @nkzawa was kind enough to replicate our results and reproduce the issue, as well as point me in the right direction to find the bug.

With this addition, I can no longer reproduce using the steps in that issue. I have not done any further testing beyond that. Note that I tried both with and without `transports: ['polling']` as I described in the issue, and I couldn't reproduce any longer.

Interestingly, with this fix, I am still seeing a delay of about 10-15 seconds after receiving the `disconnect` event, before the socket is actually closed. I'm not sure why that would be the case. But I verified, without this change, even after waiting > 60 seconds, the socket _never_ closes. So I think this fixes the issue.

I ran `make test` and all tests were passing except one--but it is also failing on `engine.io#master`.

Let me know if there is anything else I can do. I'm planning to test this change immediately in my production environment (about ~200 clients), so I'll report my results here.