### PR TITLE
Fix transport readyState and leaking sockets

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -29,7 +29,7 @@ function noop () {};
  */
 
 function Transport (req) {
-  this.readyState = 'opening';
+  this.readyState = 'open';
 };
 
 /**


### PR DESCRIPTION
Transports are already ready when created, so readyState should be `open` rather than `opening`.
This PR will fix that a WebSocket connection is not closed when upgrade timeout, and hopefully fix fd leaks.

https://github.com/socketio/engine.io/blob/master/lib/socket.js#L169 (`readyState` would never be `open` here)

Related: https://github.com/socketio/engine.io/pull/336