### PR TITLE
Fix extraHeaders option and ping timeout tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "mocha": "1.12.0",
     "expect.js": "0.2.0",
     "superagent": "0.15.4",
-    "engine.io-client": "1.5.2",
+    "engine.io-client": "socketio/engine.io-client#d010541",
     "s": "0.1.1"
   },
   "scripts": {

--- a/test/server.js
+++ b/test/server.js
@@ -379,8 +379,9 @@ describe('server', function () {
       var engine = listen(opts, function (port) {
         var socket = new eioc.Socket('ws://localhost:%d'.s(port));
         socket.on('open', function () {
-          // override onPacket to simulate an inactive server after handshake
+          // override onPacket and Transport#onClose to simulate an inactive server after handshake
           socket.onPacket = function(){};
+          socket.transport.onClose = function(){};
           socket.on('close', function (reason, err) {
             expect(reason).to.be('ping timeout');
             done();
@@ -405,8 +406,9 @@ describe('server', function () {
         });
 
         socket.on('open', function () {
-          // override onPacket to simulate an inactive server after handshake
+          // override onPacket and Transport#onClose to simulate an inactive server after handshake
           socket.onPacket = socket.sendPacket = function(){};
+          socket.transport.onClose = function(){};
           socket.on('close', onClose);
         });
       });
@@ -1697,7 +1699,7 @@ describe('server', function () {
           setTimeout(function() {
             expect(i).to.be(j);
             done();
-          }, 10);
+          }, 100);
         });
       });
 
@@ -1722,7 +1724,7 @@ describe('server', function () {
           setTimeout(function () {
             expect(i).to.be(j);
             done();
-          }, 10);
+          }, 100);
         });
       });
 


### PR DESCRIPTION
Fixed a few ping timeout tests have become unstable due to https://github.com/socketio/engine.io/pull/336.
We just have to use the master branch of engine.io-client to fix extraHeaders option.