### PR TITLE
update package dependency to support iojs 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "debug": "2.1.3",
-    "ws": "0.7.2",
+    "ws": "0.8.0",
     "engine.io-parser": "1.2.1",
     "base64id": "0.1.0",
     "accepts": "1.1.4"


### PR DESCRIPTION
updated dependency to use updated 'ws' that working with iojs 3.x buffers