### PR TITLE
base64id is not devDependency but dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "base64id": "0.1.0",
     "debug": "2.1.3",
     "ws": "0.8.0",
     "engine.io-parser": "1.2.2",
@@ -35,7 +36,6 @@
     "expect.js": "0.2.0",
     "superagent": "0.15.4",
     "engine.io-client": "socketio/engine.io-client#da24c1f",
-    "base64id": "0.1.0",
     "s": "0.1.1"
   },
   "scripts": {


### PR DESCRIPTION
`lib/server.js` uses `base64id`
https://github.com/socketio/engine.io/blob/0e70cf26d09ce121847ac178c0723c23316c565d/lib/server.js#L10
`v1.5.4` has `base64id` as dependency
https://github.com/socketio/engine.io/blob/6032a13cbeb45641cf0321c7fdf48d6e2ecec757/package.json#L27

https://github.com/socketio/engine.io/pull/350