### PR TITLE
Update “debug” to avoid vulnerability in “ms”

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "base64id": "0.1.0",
-    "debug": "2.1.3",
+    "debug": "^2.2.0",
     "ws": "0.8.0",
     "engine.io-parser": "1.2.2",
     "accepts": "1.1.4"


### PR DESCRIPTION
[Package `ms` is vulnerable to DoS attacks](https://nodesecurity.io/advisories/46). The issue was fixed in `v0.7.1`.

Package `debug` was updated accordingly in `v2.2.0`.

This PR updates the required version of `debug` ([Node Security tools](https://www.npmjs.com/package/nsp) will complain and fail until this is fixed).