### PR TITLE
Don't compress control packets

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -89,7 +89,7 @@ Socket.prototype.onPacket = function (packet) {
 
       case 'ping':
         debug('got ping');
-        this.sendPacket('pong');
+        this.sendPacket('pong', null, { compress: false });
         this.emit('heartbeat');
         break;
 
@@ -188,7 +188,7 @@ Socket.prototype.maybeUpgrade = function (transport) {
 
   function onPacket(packet){
     if ('ping' == packet.type && 'probe' == packet.data) {
-      transport.send([{ type: 'pong', data: 'probe', options: { compress: true } }]);
+      transport.send([{ type: 'pong', data: 'probe', options: { compress: false } }]);
       self.emit('upgrading', transport);
       clearInterval(self.checkIntervalTimer);
       self.checkIntervalTimer = setInterval(check, 100);
@@ -216,7 +216,7 @@ Socket.prototype.maybeUpgrade = function (transport) {
   function check(){
     if ('polling' == self.transport.name && self.transport.writable) {
       debug('writing a noop packet to polling for fast upgrade');
-      self.transport.send([{ type: 'noop', options: { compress: true } }]);
+      self.transport.send([{ type: 'noop', options: { compress: false } }]);
     }
   }
 

--- a/lib/transports/polling.js
+++ b/lib/transports/polling.js
@@ -109,7 +109,7 @@ Polling.prototype.onPollRequest = function (req, res) {
   // if we're still writable but had a pending close, trigger an empty send
   if (this.writable && this.shouldClose) {
     debug('triggering empty send to append close packet');
-    this.send([{ type: 'noop', options: { compress: true } }]);
+    this.send([{ type: 'noop', options: { compress: false } }]);
   }
 };
 
@@ -225,7 +225,7 @@ Polling.prototype.onData = function (data) {
 Polling.prototype.onClose = function () {
   if (this.writable) {
     // close pending poll request
-    this.send([{ type: 'noop', options: { compress: true } }]);
+    this.send([{ type: 'noop', options: { compress: false } }]);
   }
   Transport.prototype.onClose.call(this);
 };
@@ -242,7 +242,7 @@ Polling.prototype.send = function (packets) {
 
   if (this.shouldClose) {
     debug('appending close packet to payload');
-    packets.push({ type: 'close', options: { compress: true } });
+    packets.push({ type: 'close', options: { compress: false } });
     this.shouldClose();
     this.shouldClose = null;
   }
@@ -378,7 +378,7 @@ Polling.prototype.doClose = function (fn) {
 
   if (this.writable) {
     debug('transport writable - closing right away');
-    this.send([{ type: 'close', options: { compress: true } }]);
+    this.send([{ type: 'close', options: { compress: false } }]);
     onClose();
   } else {
     debug('transport not writable - buffering orderly close');


### PR DESCRIPTION
I think we should not compress small data since it's not efficient. Actually, compression sometimes increases data size, like from 6 byte to 13 byte. 
This PR stop compressing `pong`, `noop` and `close` packets. 