### PR TITLE
server: use `yeast` to generate the socket id

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -5,7 +5,7 @@
 
 var qs = require('querystring')
   , parse = require('url').parse
-  , base64id = require('base64id')
+  , yeast = require('yeast')
   , transports = require('./transports')
   , EventEmitter = require('events').EventEmitter
   , Socket = require('./socket')
@@ -245,7 +245,7 @@ function sendErrorMessage(req, res, code) {
  */
 
 Server.prototype.generateId = function(req){
-  return base64id.generateId();
+  return yeast();
 };
 
 /**

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,8 +5,6 @@
 
 var qs = require('querystring')
   , parse = require('url').parse
-  , readFileSync = require('fs').readFileSync
-  , crypto = require('crypto')
   , base64id = require('base64id')
   , transports = require('./transports')
   , EventEmitter = require('events').EventEmitter
@@ -222,21 +220,21 @@ Server.prototype.handleRequest = function(req, res){
  * @api private
  */
 
- function sendErrorMessage(req, res, code) {
-    var headers = { 'Content-Type': 'application/json' };
+function sendErrorMessage(req, res, code) {
+  var headers = { 'Content-Type': 'application/json' };
 
-    if (req.headers.origin) {
-      headers['Access-Control-Allow-Credentials'] = 'true';
-      headers['Access-Control-Allow-Origin'] = req.headers.origin;
-    } else {
-      headers['Access-Control-Allow-Origin'] = '*';
-    }
-    res.writeHead(400, headers);
-    res.end(JSON.stringify({
-      code: code,
-      message: Server.errorMessages[code]
-    }));
- }
+  if (req.headers.origin) {
+    headers['Access-Control-Allow-Credentials'] = 'true';
+    headers['Access-Control-Allow-Origin'] = req.headers.origin;
+  } else {
+    headers['Access-Control-Allow-Origin'] = '*';
+  }
+  res.writeHead(400, headers);
+  res.end(JSON.stringify({
+    code: code,
+    message: Server.errorMessages[code]
+  }));
+}
 
 /**
  * generate a socket id.
@@ -432,9 +430,9 @@ Server.prototype.attach = function(server, options){
         // and if no eio thing handles the upgrade
         // then the socket needs to die!
         setTimeout(function() {
-           if (socket.writable && socket.bytesWritten <= 0) {
-             return socket.end();
-           }
+          if (socket.writable && socket.bytesWritten <= 0) {
+            return socket.end();
+          }
         }, options.destroyUpgradeTimeout);
       }
     });

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "base64id": "0.1.0",
+    "accepts": "1.1.4",
     "debug": "2.2.0",
-    "ws": "0.8.1",
     "engine.io-parser": "1.2.2",
-    "accepts": "1.1.4"
+    "ws": "0.8.1",
+    "yeast": "0.1.2"
   },
   "devDependencies": {
     "engine.io-client": "1.6.3",


### PR DESCRIPTION
This patch replaces `base64id` with `yeast`.
`yeast` is a lot faster:
```
macbook:bench luigi$ node index.js 
base64id x 95,893 ops/sec ±0.93% (87 runs sampled)
yeast x 566,611 ops/sec ±0.92% (90 runs sampled)
Fastest is yeast
```
and the generated ID is shorter (7 chars).