### PR TITLE
polling: don't set the `closeTimeoutTimer` if the transport is upgraded

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -195,6 +195,7 @@ Socket.prototype.maybeUpgrade = function (transport) {
     } else if ('upgrade' == packet.type && self.readyState != 'closed') {
       debug('got upgrade packet - upgrading');
       cleanup();
+      self.transport.discard();
       self.upgraded = true;
       self.clearTransport();
       self.setTransport(transport);

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -19,7 +19,7 @@ module.exports = Transport;
  * @api private
  */
 
-function noop () {};
+function noop () {}
 
 /**
  * Transport constructor.
@@ -30,13 +30,24 @@ function noop () {};
 
 function Transport (req) {
   this.readyState = 'open';
-};
+  this.discarded = false;
+}
 
 /**
  * Inherits from EventEmitter.
  */
 
 Transport.prototype.__proto__ = EventEmitter.prototype;
+
+/**
+ * Flags the transport as discarded.
+ *
+ * @api private
+ */
+
+Transport.prototype.discard = function () {
+  this.discarded = true;
+};
 
 /**
  * Called with an incoming HTTP request.

--- a/lib/transports/polling.js
+++ b/lib/transports/polling.js
@@ -368,6 +368,9 @@ Polling.prototype.doClose = function (fn) {
     debug('transport writable - closing right away');
     this.send([{ type: 'close' }]);
     onClose();
+  } else if (this.discarded) {
+    debug('transport discarded - closing right away');
+    onClose();
   } else {
     debug('transport not writable - buffering orderly close');
     this.shouldClose = onClose;


### PR DESCRIPTION
There is no reason to set the timer if the transport has been upgraded because:

- The transport is virtually dead (all listeners have been removed).
- The client will never send a new poll request.

Closes #376.