### PR TITLE
disabled normalize path 

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -407,13 +407,10 @@ Server.prototype.onWebSocket = function(req, socket){
 Server.prototype.attach = function(server, options){
   var self = this;
   var options = options || {};
-  var path = (options.path || '/engine.io').replace(/\/$/, '');
+  var path = (options.path || '/engine.io/');
 
   var destroyUpgrade = (options.destroyUpgrade !== undefined) ? options.destroyUpgrade : true;
   var destroyUpgradeTimeout = options.destroyUpgradeTimeout || 1000;
-
-  // normalize path
-  path += '/';
 
   function check (req) {
     return path == req.url.substr(0, path.length);


### PR DESCRIPTION
There were an issue created already 
https://github.com/socketio/engine.io/issues/360

And there was an answer that there is no specific reason to normalize path. 
I think it would be good if server listens on exact path user specifies. So if user says he wants socket-io to listen on `{path: "/ws"}` it should listen at exact same path without trailing slash.

I tried this change, and it seems to be working. I'm not completely sure - might break something else. 
