### PR TITLE
Allow adding a custom cookie path

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -44,6 +44,7 @@ function Server(opts){
   this.allowUpgrades = false !== opts.allowUpgrades;
   this.allowRequest = opts.allowRequest;
   this.cookie = false !== opts.cookie ? (opts.cookie || 'io') : false;
+  this.cookiePath = opts.cookiePath || false;
   this.perMessageDeflate = false !== opts.perMessageDeflate ? (opts.perMessageDeflate || true) : false;
   this.httpCompression = false !== opts.httpCompression ? (opts.httpCompression || {}) : false;
 
@@ -258,6 +259,9 @@ Server.prototype.handshake = function(transport, req){
   if (false !== this.cookie) {
     transport.on('headers', function(headers){
       headers['Set-Cookie'] = self.cookie + '=' + id;
+      if(false !== self.cookiePath) {
+        headers['Set-Cookie'] += '; Path= ' + self.cookiePath;
+      }
     });
   }
 

--- a/test/server.js
+++ b/test/server.js
@@ -83,6 +83,19 @@ describe('server', function () {
       });
     });
 
+    it('should send the io cookie with custom cookie path', function (done) {
+      var engine = listen({ cookiePath: '/' }, function (port) {
+        request.get('http://localhost:%d/engine.io/default/'.s(port))
+          .query({ transport: 'polling', b64: 1 })
+          .end(function (res) {
+            // hack-obtain sid
+            var sid = res.text.match(/"sid":"([^"]+)"/)[1];
+            expect(res.headers['set-cookie'][0]).to.be('io=' + sid + '; Path=/');
+            done();
+          });
+      });
+    });
+
     it('should send the io cookie custom name', function (done) {
       var engine = listen({ cookie: 'woot' }, function (port) {
         request.get('http://localhost:%d/engine.io/default/'.s(port))


### PR DESCRIPTION
I'm using the generated `sid` so I can match a socket to a normal HTTP connection in an app.

The problem is that the cookie doesn't get sent to the API endpoints because if no path is defined:
>  Path   Defaults to the path of the request URL that generated the
          Set-Cookie response, up to, but not including, the
          right-most /.

Which means only the socket.io routes will be able to read the cookies.

