### PR TITLE
Option wsEngine or EIO_WS_ENGINE env var

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,14 @@ node_js:
   - "0.10"
   - "0.12"
   - "4.0.0"
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 
 notifications:
   irc: "irc.freenode.org#socket.io"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
-  - "4.0.0"
+  - "4"
 env:
   - CXX=g++-4.8
 addons:

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ to a single process.
       - `cookiePath` (`String|Boolean`): path of the above `cookie`
         option. If false, no path will be sent, which means browsers will only send the cookie on the engine.io attached path (`/engine.io`).
         Set this to `/` to send the io cookie on all requests. (`false`)
-      - `wsEngine` (`String`): what WebSocket server implementation to use. Specified module must conform to the `ws` interface (see [ws module api docs](https://github.com/websockets/ws/blob/master/doc/ws.md)). Default value is `'ws'`.
+      - `wsEngine` (`String`): what WebSocket server implementation to use. Specified module must conform to the `ws` interface (see [ws module api docs](https://github.com/websockets/ws/blob/master/doc/ws.md)). Default value is `ws`. An alternative c++ addon is also available by installing `uws` module.
 - `close`
     - Closes all clients
     - **Returns** `Server` for chaining

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ to a single process.
       - `cookiePath` (`String|Boolean`): path of the above `cookie`
         option. If false, no path will be sent, which means browsers will only send the cookie on the engine.io attached path (`/engine.io`).
         Set this to `/` to send the io cookie on all requests. (`false`)
+      - `wsEngine` (`String`): what WebSocket server implementation to use. Specified module must conform to the `ws` interface (see [ws module api docs](https://github.com/websockets/ws/blob/master/doc/ws.md)). Default value is `'ws'`.
 - `close`
     - Closes all clients
     - **Returns** `Server` for chaining

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,10 @@ var REPORTER = 'dot';
 gulp.task("default", ["transpile"]);
 
 gulp.task('test', function(){
+    if (parseInt(process.versions.node) < 4 && process.env.EIO_WS_ENGINE == 'uws') {
+      console.info("Node version < 4, skipping tests with uws engine");
+      process.exit();
+    }
     return gulp.src(TESTS, {read: false})
     .pipe(mocha({
       slow: 500,

--- a/lib/server.js
+++ b/lib/server.js
@@ -11,7 +11,6 @@ var qs = require('querystring')
   , transports = require('./transports')
   , EventEmitter = require('events').EventEmitter
   , Socket = require('./socket')
-  , WebSocketServer = require('ws').Server
   , debug = require('debug')('engine');
 
 /**
@@ -36,6 +35,8 @@ function Server(opts){
   this.clientsCount = 0;
 
   opts = opts || {};
+
+  this.wsEngine = opts.wsEngine || process.env.EIO_WS_ENGINE || 'ws';
   this.pingTimeout = opts.pingTimeout || 60000;
   this.pingInterval = opts.pingInterval || 25000;
   this.upgradeTimeout = opts.upgradeTimeout || 10000;
@@ -69,6 +70,7 @@ function Server(opts){
 
   // initialize websocket server
   if (~this.transports.indexOf('websocket')) {
+    var WebSocketServer = require(this.wsEngine).Server;
     this.ws = new WebSocketServer({
       noServer: true,
       clientTracking: false,

--- a/package.json
+++ b/package.json
@@ -40,10 +40,11 @@
     "gulp-mocha": "2.2.0",
     "mocha": "2.3.4",
     "s": "0.1.1",
-    "superagent": "0.15.4"
+    "superagent": "0.15.4",
+    "uws": "^0.3.3"
   },
   "scripts": {
-    "test": "./node_modules/.bin/gulp test"
+    "test": "gulp test; EIO_WS_ENGINE=uws gulp test;"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "mocha": "2.3.4",
     "s": "0.1.1",
     "superagent": "0.15.4",
-    "uws": "^0.3.3"
+    "uws": "0.3.4"
   },
   "scripts": {
     "test": "gulp test; EIO_WS_ENGINE=uws gulp test;"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "mocha": "2.3.4",
     "s": "0.1.1",
     "superagent": "0.15.4",
-    "uws": "0.3.4"
+    "uws": "0.4.0"
   },
   "scripts": {
     "test": "gulp test; EIO_WS_ENGINE=uws gulp test;"

--- a/test/server.js
+++ b/test/server.js
@@ -18,6 +18,13 @@ var WebSocket = require('ws');
 
 // are we running on node 0.8?
 var NODE_0_8 = /^v0\.8\./.test(process.version);
+// are we running on node < 4.4.3 ?
+var NODE_LT_443 = (function(){
+  var parts = process.versions.node.split('.');
+  return (parts[0] < 4 || parts[1] < 4 || parts[2] < 3);
+})();
+// are we running uws wsEngine ?
+var UWS_ENGINE = process.env.EIO_WS_ENGINE == "uws";
 
 /**
  * Tests.
@@ -1431,6 +1438,7 @@ describe('server', function () {
     });
 
     it('should send and receive data with key and cert (polling)', function(done){
+      if (UWS_ENGINE && NODE_LT_443) return done();
       var srvOpts = {
         key: fs.readFileSync('test/fixtures/server.key'),
         cert: fs.readFileSync('test/fixtures/server.crt'),
@@ -1471,6 +1479,7 @@ describe('server', function () {
     });
 
     it('should send and receive data with ca when not requiring auth (polling)', function(done){
+      if (UWS_ENGINE && NODE_LT_443) return done();
       var srvOpts = {
         key: fs.readFileSync('test/fixtures/server.key'),
         cert: fs.readFileSync('test/fixtures/server.crt'),
@@ -1548,6 +1557,7 @@ describe('server', function () {
     });
 
     it('should send and receive data with pfx (polling)', function(done){
+      if (UWS_ENGINE && NODE_LT_443) return done();
       var srvOpts = {
         key: fs.readFileSync('test/fixtures/server.key'),
         cert: fs.readFileSync('test/fixtures/server.crt'),
@@ -1587,6 +1597,7 @@ describe('server', function () {
     });
 
     it('should send and receive data with pfx (ws)', function(done){
+      if (UWS_ENGINE && NODE_LT_443) return done();
       var srvOpts = {
         key: fs.readFileSync('test/fixtures/server.key'),
         cert: fs.readFileSync('test/fixtures/server.crt'),
@@ -2424,7 +2435,7 @@ describe('server', function () {
     });
   });
 
-  if (parseInt(process.versions.node) >= 4) describe('wsEngine option', function() {
+  if (!UWS_ENGINE && parseInt(process.versions.node) >= 4) describe('wsEngine option', function() {
     it('should allow loading of other websocket server implementation like uws', function(done) {
       var engine = listen({ allowUpgrades: false, wsEngine: 'uws' }, function (port) {
         expect(engine.ws instanceof require('uws').Server).to.be.ok();

--- a/test/server.js
+++ b/test/server.js
@@ -2424,7 +2424,7 @@ describe('server', function () {
     });
   });
 
-  describe('wsEngine option', function() {
+  if (parseInt(process.versions.node) >= 4) describe('wsEngine option', function() {
     it('should allow loading of other websocket server implementation like uws', function(done) {
       var engine = listen({ allowUpgrades: false, wsEngine: 'uws' }, function (port) {
         expect(engine.ws instanceof require('uws').Server).to.be.ok();

--- a/test/server.js
+++ b/test/server.js
@@ -2423,4 +2423,22 @@ describe('server', function () {
       testForHeaders(headers, done);
     });
   });
+
+  describe('wsEngine option', function() {
+    it('should allow loading of other websocket server implementation like uws', function(done) {
+      var engine = listen({ allowUpgrades: false, wsEngine: 'uws' }, function (port) {
+        expect(engine.ws instanceof require('uws').Server).to.be.ok();
+        var socket = new eioc.Socket('ws://localhost:%d'.s(port));
+        engine.on('connection', function (conn) {
+          conn.send('a');
+        });
+        socket.on('open', function () {
+          socket.on('message', function (msg) {
+            expect(msg).to.be('a');
+            done();
+          });
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
This gives ability to dynamically choose ws implementation, either programmatically or by environment variable, the reason being the availability of the [uWebSocket alternative](https://github.com/alexhultman/uWebSockets) - which will eventually pass the test suite.
That alternative cannot be a definitive replacement for `ws` module because it is an addon,
and users need to be able to choose between both solutions.
