### PR TITLE
Add wsServerModule option, document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ to a single process.
       - `cookiePath` (`String|Boolean`): path of the above `cookie`
         option. If false, no path will be sent, which means browsers will only send the cookie on the engine.io attached path (`/engine.io`).
         Set this to `/` to send the io cookie on all requests. (`false`)
+      - `wsServerModule` (`String`): what WebSocket server implementation to use. Specified module must conform to the `ws` interface (see [ws module api docs](https://github.com/websockets/ws/blob/master/doc/ws.md)). Default value is `'ws'`.
 - `close`
     - Closes all clients
     - **Returns** `Server` for chaining

--- a/lib/server.js
+++ b/lib/server.js
@@ -11,7 +11,8 @@ var qs = require('querystring')
   , transports = require('./transports')
   , EventEmitter = require('events').EventEmitter
   , Socket = require('./socket')
-  , WebSocketServer = require('ws').Server
+  , currentWsServerModule = 'ws'
+  , WebSocketServer = require(currentWsServerModule).Server
   , debug = require('debug')('engine');
 
 /**
@@ -47,6 +48,13 @@ function Server(opts){
   this.cookiePath = false !== opts.cookiePath ? (opts.cookiePath || false) : false;
   this.perMessageDeflate = false !== opts.perMessageDeflate ? (opts.perMessageDeflate || true) : false;
   this.httpCompression = false !== opts.httpCompression ? (opts.httpCompression || {}) : false;
+  this.wsServerModule = opts.wsServerModule || process.env.EIO_WS_SERVER_MODULE || 'ws';
+  
+  // if needed, update WebSocketServer according to passed options
+  if (currentWsServerModule !== this.wsServerModule) {
+    currentWsServerModule = this.wsServerModule;
+    WebSocketServer = require(currentWsServerModule).Server;
+  }
 
   var self = this;
 


### PR DESCRIPTION
This is similar to PR #390 but lazily swaps the implementation based on need. It doesn't call `require` every time you instantiate a Server. Also, the name is corrected from `wsModule` to `wsServerModule` since we want to be future proof to allow wsClientModule option. Minimal documentation is added.