### PR TITLE
Close and free webSocketServer

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -182,6 +182,11 @@ Server.prototype.close = function(){
       this.clients[i].close(true);
     }
   }
+  if (this.ws) {
+    debug('closing webSocketServer');
+    this.ws.close();
+    delete this.ws;
+  }
   return this;
 };
 


### PR DESCRIPTION
Is there an undocumented reason not to call `ws.close()` ?