### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   "dependencies": {
     "base64id": "0.1.0",
     "debug": "2.2.0",
-    "ws": "1.0.1",
+    "ws": "1.1.0",
     "engine.io-parser": "1.2.4",
-    "accepts": "1.1.4"
+    "accepts": "1.3.3"
   },
   "devDependencies": {
     "babel-preset-es2015": "6.3.13",


### PR DESCRIPTION
There is an issue when using `nexe` (for bundling binaries) with the old version of negotiator,
because of a hacky usage of require: `require('./'+k+'.js'),`