### PR TITLE
Adding nsp check to the build process

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,13 +1,14 @@
 var gulp = require('gulp');
 var mocha = require('gulp-mocha');
 var babel = require("gulp-babel");
+var nsp = require('gulp-nsp');
 
 var TESTS = 'test/*.js';
 var REPORTER = 'dot';
 
 gulp.task("default", ["transpile"]);
 
-gulp.task('test', function(){
+gulp.task('test', ['nsp'], function(){
     if (parseInt(process.versions.node) < 4 && process.env.EIO_WS_ENGINE == 'uws') {
       console.info("Node version < 4, skipping tests with uws engine");
       process.exit();
@@ -32,3 +33,7 @@ gulp.task("transpile", function(){
         .pipe(babel({ "presets": ["es2015"] }))
         .pipe(gulp.dest("dist"));
 });
+
+gulp.task('nsp', function (cb) {
+  nsp({package: __dirname + '/package.json'}, cb)
+})

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "base64id": "0.1.0",
     "debug": "2.2.0",
     "engine.io-parser": "1.2.4",
-    "ws": "1.1.0"
+    "ws": "1.1.1"
   },
   "devDependencies": {
     "babel-preset-es2015": "6.3.13",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "gulp": "3.9.0",
     "gulp-babel": "6.1.1",
     "gulp-mocha": "2.2.0",
+    "gulp-nsp": "^2.4.1",
     "mocha": "2.3.4",
     "s": "0.1.1",
     "superagent": "0.15.4",


### PR DESCRIPTION
Recently there've been a few security vulnerabilities discovered in dependencies of engine.io (such as #401 and #410, among others).

This PR adds an `nsp` check to the test process, such that when the `gulp test` command is run, engine.io's dependencies are scanned for vulnerabilities by nsp.

This way, the build will fail immediately when there's a vulnerable dependency, making it obvious that the dependency's version needs updating.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>