### PR TITLE
enable session sharing via redis

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -377,7 +377,7 @@ Server.prototype.handshake = function(transportName, req){
   debug('handshaking client "%s"', id);
     
   var self = this;
-  this.setupClient(transport, id, req, function (socket) { 
+  this.setupClient(transportName, id, req, function (socket) {
     socket.once('close', function(){
       self.client(id, null, function () { 
         self.clientsCount--;

--- a/lib/server.js
+++ b/lib/server.js
@@ -128,22 +128,31 @@ Server.prototype.clients;
 Server.prototype.client = function (sid, value, fn) {
   if (!sid) return;
   if (redis === undefined) {
-    if ("function" === typeof value || value === undefined)
-      value(this.sessions[sid]);
-    else if (value === null)
+    if ("function" === typeof value && fn === undefined)
+      value(null, this.sessions[sid]);
+    else if (value === null) {
       delete this.sessions[sid];
-    else
+      if ("function" === typeof fn) fn(null, true);
+    } else {
       this.sessions[sid] = value;
+      if ("function" === typeof fn) fn(null, value);
+    }
   } else {
-    var json;
-    if ("function" === typeof value || (json = JSON.stringify(value)) === undefined)
+    if ("function" === typeof value && fn === undefined)
       redis.hget(["engine.io", sid], function(err, val) {
-        if (!err && "function" === typeof value) value(JSON.parse(val));
-      })
+        if(err) value(err);
+        else value(null, JSON.parse(val));
+      });
     else if(value===null)
-      redis.hdel(["engine.io", sid])
+      redis.hdel(["engine.io", sid], function(err, val){
+          if (err) value(err);
+          else value(null, true);
+      });
     else
-      redis.hset(["engine.io", sid, json]);
+      redis.hset(["engine.io", sid, JSON.stringify(value)], function(err, val){
+          if (err) value(err);
+          else value(null, value);
+      });
   }
 }
 
@@ -178,10 +187,10 @@ Server.prototype.verify = function(req, upgrade, fn){
   // sid check
   var sid = req._query.sid;
   if (sid) {
-    this.client(sid, function(client) {
+    this.client(sid, function(err, client) {
       if (!client)
         return fn(Server.errors.UNKNOWN_SID, false);
-      if (!upgrade && client.transport !== transport) {
+      if (!upgrade && client.transport.name !== transport) {
         debug('bad request: unexpected transport without upgrade');
         return fn(Server.errors.BAD_REQUEST, false);
       }
@@ -304,14 +313,16 @@ Server.prototype.setupClient = function (transportName, id, req, fn) {
 
   transport.onRequest(req);
 
-  this.client(id, function(client) {
+  this.client(id, function(err, client) {
     self.clients[id] = socket;
     if (client){
       fn(socket);
     } else {
-      self.client(id, socket);
-      self.clientsCount++;
-      fn(socket);
+      self.client(id, socket, function (err, _client) { 
+        if (err) return;
+        self.clientsCount++;
+        fn(socket);
+      });
     }
   });
 }
@@ -368,9 +379,10 @@ Server.prototype.handshake = function(transportName, req){
   var self = this;
   this.setupClient(transport, id, req, function (socket) { 
     socket.once('close', function(){
-      self.client(id, null);
-      delete self.clients[id];
-      self.clientsCount--;
+      self.client(id, null, function () { 
+        self.clientsCount--;
+        delete self.clients[id];
+      });
     });
 
     self.emit('connection', socket);

--- a/lib/server.js
+++ b/lib/server.js
@@ -11,7 +11,8 @@ var qs = require('querystring')
   , transports = require('./transports')
   , EventEmitter = require('events').EventEmitter
   , Socket = require('./socket')
-  , debug = require('debug')('engine');
+  , debug = require('debug')('engine')
+  , redis;
 
 /**
  * Module exports.
@@ -78,6 +79,13 @@ function Server(opts){
       maxPayload: this.maxHttpBufferSize
     });
   }
+
+  //initialize session store
+  this.session_store = opts.session_store || null;
+  if (this.session_store && this.session_store.host && this.session_store.port)
+      redis = require('redis').createClient(this.session_store.port, this.session_store.host);
+  else
+      this.sessions = {};
 }
 
 /**
@@ -112,6 +120,33 @@ Server.prototype.__proto__ = EventEmitter.prototype;
 
 Server.prototype.clients;
 
+/*
+ * Get a client from session store
+ * 
+ * @api private
+ */
+Server.prototype.client = function (sid, value, fn) {
+  if (!sid) return;
+  if (redis === undefined) {
+    if ("function" === typeof value || value === undefined)
+      value(this.sessions[sid]);
+    else if (value === null)
+      delete this.sessions[sid];
+    else
+      this.sessions[sid] = value;
+  } else {
+    var json;
+    if ("function" === typeof value || (json = JSON.stringify(value)) === undefined)
+      redis.hget(["engine.io", sid], function(err, val) {
+        if (!err && "function" === typeof value) value(JSON.parse(val));
+      })
+    else if(value===null)
+      redis.hdel(["engine.io", sid])
+    else
+      redis.hset(["engine.io", sid, json]);
+  }
+}
+
 /**
  * Returns a list of available transports for upgrade given a certain transport.
  *
@@ -143,20 +178,21 @@ Server.prototype.verify = function(req, upgrade, fn){
   // sid check
   var sid = req._query.sid;
   if (sid) {
-    if (!this.clients.hasOwnProperty(sid))
-      return fn(Server.errors.UNKNOWN_SID, false);
-    if (!upgrade && this.clients[sid].transport.name !== transport) {
-      debug('bad request: unexpected transport without upgrade');
-      return fn(Server.errors.BAD_REQUEST, false);
-    }
+    this.client(sid, function(client) {
+      if (!client)
+        return fn(Server.errors.UNKNOWN_SID, false);
+      if (!upgrade && client.transport !== transport) {
+        debug('bad request: unexpected transport without upgrade');
+        return fn(Server.errors.BAD_REQUEST, false);
+      }
+      return fn(null, true);
+    })
   } else {
     // handshake is GET only
     if ('GET' != req.method) return fn(Server.errors.BAD_HANDSHAKE_METHOD, false);
     if (!this.allowRequest) return fn(null, true);
     return this.allowRequest(req, fn);
   }
-
-  fn(null, true);
 };
 
 /**
@@ -210,12 +246,75 @@ Server.prototype.handleRequest = function(req, res){
 
     if (req._query.sid) {
       debug('setting new request for existing client');
-      self.clients[req._query.sid].transport.onRequest(req);
+      self.setupClient(req._query.transport, req._query.sid, req, function(socket) {
+        socket.transport.onRequest(req);
+      });
     } else {
       self.handshake(req._query.transport, req);
     }
   });
 };
+
+
+/**
+ * Setups a new Client
+ *
+ * @param {String} transport name
+ * @param {Number} client id
+ * @param {Object} request object
+ * @api private
+ */
+
+Server.prototype.setupClient = function (transportName, id, req, fn) {
+  debug('setup a client "%s"', id);
+    
+  if (this.clients[id]) return fn(this.clients[id]);
+
+  try {
+    var transport = new transports[transportName](req);
+    if ('polling' == transportName) {
+      transport.maxHttpBufferSize = this.maxHttpBufferSize;
+      transport.httpCompression = this.httpCompression;
+    } else if ('websocket' == transportName) {
+      transport.perMessageDeflate = this.perMessageDeflate;
+    }
+
+    if (req._query && req._query.b64) {
+      transport.supportsBinary = false;
+    } else {
+      transport.supportsBinary = true;
+    }
+  }
+  catch (e) {
+    sendErrorMessage(req, req.res, Server.errors.BAD_REQUEST);
+    return;
+  }
+  var socket = new Socket(id, this, transport, req);
+  var self = this;
+
+  if (false !== this.cookie) {
+    transport.on('headers', function(headers){
+      var cookie = self.cookie + '=' + id;
+      if(false !== self.cookiePath) {
+        cookie += '; path=' + self.cookiePath;
+      }
+      headers['Set-Cookie'] = cookie;
+    });
+  }
+
+  transport.onRequest(req);
+
+  this.client(id, function(client) {
+    self.clients[id] = socket;
+    if (client){
+      fn(socket);
+    } else {
+      self.client(id, socket);
+      self.clientsCount++;
+      fn(socket);
+    }
+  });
+}
 
 /**
  * Sends an Engine.IO Error Message
@@ -265,50 +364,17 @@ Server.prototype.handshake = function(transportName, req){
   var id = this.generateId(req);
 
   debug('handshaking client "%s"', id);
-
-  try {
-    var transport = new transports[transportName](req);
-    if ('polling' == transportName) {
-      transport.maxHttpBufferSize = this.maxHttpBufferSize;
-      transport.httpCompression = this.httpCompression;
-    } else if ('websocket' == transportName) {
-      transport.perMessageDeflate = this.perMessageDeflate;
-    }
-
-    if (req._query && req._query.b64) {
-      transport.supportsBinary = false;
-    } else {
-      transport.supportsBinary = true;
-    }
-  }
-  catch (e) {
-    sendErrorMessage(req, req.res, Server.errors.BAD_REQUEST);
-    return;
-  }
-  var socket = new Socket(id, this, transport, req);
+    
   var self = this;
-
-  if (false !== this.cookie) {
-    transport.on('headers', function(headers){
-      var cookie = self.cookie + '=' + id;
-      if(false !== self.cookiePath) {
-        cookie += '; path=' + self.cookiePath;
-      }
-      headers['Set-Cookie'] = cookie;
+  this.setupClient(transport, id, req, function (socket) { 
+    socket.once('close', function(){
+      self.client(id, null);
+      delete self.clients[id];
+      self.clientsCount--;
     });
-  }
 
-  transport.onRequest(req);
-
-  this.clients[id] = socket;
-  this.clientsCount++;
-
-  socket.once('close', function(){
-    delete self.clients[id];
-    self.clientsCount--;
+    self.emit('connection', socket);
   });
-
-  this.emit('connection', socket);
 };
 
 /**
@@ -356,36 +422,35 @@ Server.prototype.onWebSocket = function(req, socket){
 
   // get client id
   var id = req._query.sid;
+  var self = this;
 
   // keep a reference to the ws.Socket
   req.websocket = socket;
 
   if (id) {
-    var client = this.clients[id];
-    if (!client) {
-      debug('upgrade attempt for closed client');
-      socket.close();
-    } else if (client.upgrading) {
-      debug('transport has already been trying to upgrade');
-      socket.close();
-    } else if (client.upgraded) {
-      debug('transport had already been upgraded');
-      socket.close();
-    } else {
-      debug('upgrading existing transport');
-
-      // transport error handling takes over
-      socket.removeListener('error', onUpgradeError);
-
-      var transport = new transports[req._query.transport](req);
-      if (req._query && req._query.b64) {
-        transport.supportsBinary = false;
+    this.setupClient(req._query.transport, id, req, function (client) {
+      if (!client) {
+        debug('upgrade attempt for closed client');
+        socket.close();
+      } else if (client.upgraded) {
+        debug('transport had already been upgraded');
+        socket.close();
       } else {
-        transport.supportsBinary = true;
+        debug('upgrading existing transport');
+          
+        // transport error handling takes over
+        socket.removeListener('error', onUpgradeError);
+
+        var transport = new transports[req._query.transport](req);
+        if (req._query && req._query.b64) {
+          transport.supportsBinary = false;
+        } else {
+          transport.supportsBinary = true;
+        }
+        transport.perMessageDeflate = self.perMessageDeflate;
+        client.maybeUpgrade(transport);
       }
-      transport.perMessageDeflate = this.perMessageDeflate;
-      client.maybeUpgrade(transport);
-    }
+    });
   } else {
     // transport error handling takes over
     socket.removeListener('error', onUpgradeError);

--- a/lib/server.js
+++ b/lib/server.js
@@ -141,12 +141,12 @@ Server.prototype.client = function (sid, value, fn) {
     if ("function" === typeof value && fn === undefined)
       redis.hget(["engine.io", sid], function(err, val) {
         if(err) value(err);
-        else value(null, JSON.parse(val));
+        else if ("function" === typeof fn) fn(null, JSON.parse(val));
       });
     else if(value===null)
       redis.hdel(["engine.io", sid], function(err, val){
           if (err) value(err);
-          else value(null, true);
+          else if ("function" === typeof fn) fn(null, true);
       });
     else
       redis.hset(["engine.io", sid, JSON.stringify(value)], function(err, val){

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -46,6 +46,9 @@ function Socket (id, server, transport, req) {
 
 Socket.prototype.__proto__ = EventEmitter.prototype;
 
+Socket.prototype.toJSON = function () {
+  return { id: this.id, transport: this.transport && this.transport.name || '' };
+}
 /**
  * Called upon transport considered open.
  *

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -47,7 +47,7 @@ function Socket (id, server, transport, req) {
 Socket.prototype.__proto__ = EventEmitter.prototype;
 
 Socket.prototype.toJSON = function () {
-  return { id: this.id, transport: this.transport && this.transport.name || '' };
+  return { id: this.id, transport: { name: this.transport && this.transport.name || '' } };
 }
 /**
  * Called upon transport considered open.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "base64id": "0.1.0",
     "debug": "2.2.0",
     "engine.io-parser": "1.2.4",
+    "redis": "^2.6.2",
     "ws": "1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I was wondering if is is possible to add this feature into engine.io, since it is very hard to run a engine.io/socket.io using nodes native cluster module (I use pm2 which uses it), and the only workarounds I found are pretty hackey.

this obviously adds a dependency for the redis module which is not allways needed, mabe there is a solution for that, but this enables engine.io to work in an un-statfull way.

i'd love to get feedback about this feature.
