### PR TITLE
Restoring require('ws') as separate expression for browserify.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -36,7 +36,7 @@ function Server(opts){
 
   opts = opts || {};
 
-  this.wsEngine = opts.wsEngine || process.env.EIO_WS_ENGINE || 'ws';
+  this.wsEngine = opts.wsEngine || process.env.EIO_WS_ENGINE;
   this.pingTimeout = opts.pingTimeout || 60000;
   this.pingInterval = opts.pingInterval || 25000;
   this.upgradeTimeout = opts.upgradeTimeout || 10000;
@@ -70,7 +70,8 @@ function Server(opts){
 
   // initialize websocket server
   if (~this.transports.indexOf('websocket')) {
-    var WebSocketServer = require(this.wsEngine).Server;
+    // keep require('ws') as separate expression for packers (browserify, etc)
+    var WebSocketServer = (this.wsEngine ? require(this.wsEngine) : require('ws')).Server;
     this.ws = new WebSocketServer({
       noServer: true,
       clientTracking: false,


### PR DESCRIPTION
Cherry-pick from https://github.com/socketio/engine.io/pull/397.

Reference https://github.com/socketio/engine.io/pull/390#issuecomment-222500758
> @rauchg, @kapouer Guys, this PR breaks the ability to pack socket.io / engine.io with browserify because it is not able to detect the module name anymore. I.e. every time require with variable breaks it. I'm going to fix it in #397 to avoid creating a new PR.

Closes #397