### PR TITLE
Bump package version after ws package received an update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "engine.io",
-  "version": "1.6.11",
+  "version": "1.6.12",
   "description": "The realtime engine behind Socket.IO. Provides the foundation of a bidirectional connection between client and server",
   "main": "./lib/engine.io",
   "author": "Guillermo Rauch <guillermo@learnboost.com>",


### PR DESCRIPTION
This update need to be merged and a new package must be sent to npm to make sure that `socket.io` and other dependent libraries pull in the updated version with the fix for the `ws` vulnerability.
cc @darrachequesne and other contributors/core team