### PR TITLE
Only add defined callbacks to the stack

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -393,8 +393,8 @@ Socket.prototype.sendPacket = function (type, data, options, callback) {
 
     this.writeBuffer.push(packet);
 
-    // add send callback to object
-    this.packetsFn.push(callback);
+    // add send callback to object, if defined
+    if (callback) this.packetsFn.push(callback);
 
     this.flush();
   }


### PR DESCRIPTION
### The kind of change this PR does introduce

* a bug fix

### Current behaviour

Before that commit, undefined callbacks were also added to the array,
which could lead to 'Maximum call stack size exceeded' error when
flush() method was called.

### New behaviour


### Other information (e.g. related issues)

Fixes #399 
Fixes https://github.com/socketio/socket.io/issues/2589