### PR TITLE
Rename ServerRequest to IncomingMessage in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,13 +233,13 @@ to a single process.
 - `handleRequest`
     - Called internally when a `Engine` request is intercepted.
     - **Parameters**
-      - `http.ServerRequest`: a node request object
+      - `http.IncomingMessage`: a node request object
       - `http.ServerResponse`: a node response object
     - **Returns** `Server` for chaining
 - `handleUpgrade`
     - Called internally when a `Engine` ws upgrade is intercepted.
     - **Parameters** (same as `upgrade` event)
-      - `http.ServerRequest`: a node request object
+      - `http.IncomingMessage`: a node request object
       - `net.Stream`: TCP socket for the request
       - `Buffer`: legacy tail bytes
     - **Returns** `Server` for chaining
@@ -258,7 +258,7 @@ to a single process.
     - Generate a socket id.
     - Overwrite this method to generate your custom socket id.
     - **Parameters**
-      - `http.ServerRequest`: a node request object
+      - `http.IncomingMessage`: a node request object
   - **Returns** A socket id for connected client.
 
 <hr><br>
@@ -303,7 +303,7 @@ A representation of a client. _Inherits from EventEmitter_.
 
 - `id` _(String)_: unique identifier
 - `server` _(Server)_: engine parent reference
-- `request` _(http.ServerRequest)_: request that originated the Socket
+- `request` _(http.IncomingMessage)_: request that originated the Socket
 - `upgraded` _(Boolean)_: whether the transport has been upgraded
 - `readyState` _(String)_: opening|open|closing|closed
 - `transport` _(Transport)_: transport reference

--- a/lib/server.js
+++ b/lib/server.js
@@ -129,7 +129,7 @@ Server.prototype.upgrades = function (transport) {
 /**
  * Verifies a request.
  *
- * @param {http.ServerRequest}
+ * @param {http.IncomingMessage}
  * @return {Boolean} whether the request is valid
  * @api private
  */
@@ -199,7 +199,7 @@ Server.prototype.close = function () {
 /**
  * Handles an Engine.IO HTTP request.
  *
- * @param {http.ServerRequest} request
+ * @param {http.IncomingMessage} request
  * @param {http.ServerResponse|http.OutgoingMessage} response
  * @api public
  */


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

Documentation uses `http.ServerRequest` for node request objects

### New behaviour

Documentation uses `http.IncomingMessage` for node request objects

### Other information (e.g. related issues)

According to the node http [documentation](https://nodejs.org/api/http.html#http_class_http_incomingmessage), correct name for a node request class is `IncomingMessage`.

