### PR TITLE
`allowRequest` failures now return 403 Forbidden

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -90,14 +90,16 @@ Server.errors = {
   UNKNOWN_TRANSPORT: 0,
   UNKNOWN_SID: 1,
   BAD_HANDSHAKE_METHOD: 2,
-  BAD_REQUEST: 3
+  BAD_REQUEST: 3,
+  FORBIDDEN: 4
 };
 
 Server.errorMessages = {
   0: 'Transport unknown',
   1: 'Session ID unknown',
   2: 'Bad handshake method',
-  3: 'Bad request'
+  3: 'Bad request',
+  4: 'Forbidden'
 };
 
 /**
@@ -236,6 +238,15 @@ Server.prototype.handleRequest = function (req, res) {
 function sendErrorMessage (req, res, code) {
   var headers = { 'Content-Type': 'application/json' };
 
+  var isForbidden = !Server.errorMessages.hasOwnProperty(code);
+  if (isForbidden) {
+    res.writeHead(403, headers);
+    res.end(JSON.stringify({
+      code: Server.errors.FORBIDDEN,
+      message: code || Server.errorMessages[Server.errors.FORBIDDEN]
+    }));
+    return;
+  }
   if (req.headers.origin) {
     headers['Access-Control-Allow-Credentials'] = 'true';
     headers['Access-Control-Allow-Origin'] = req.headers.origin;

--- a/test/server.js
+++ b/test/server.js
@@ -78,6 +78,22 @@ describe('server', function () {
           });
       });
     });
+
+    it('should disallow requests that are rejected by `allowRequest`', function (done) {
+      listen({ allowRequest: function (req, fn) { fn('Thou shall not pass', false); } }, function (port) {
+        request.get('http://localhost:%d/engine.io/default/'.s(port))
+          .set('Origin', 'http://engine.io')
+          .query({ transport: 'polling' })
+          .end(function (res) {
+            expect(res.status).to.be(403);
+            expect(res.body.code).to.be(4);
+            expect(res.body.message).to.be('Thou shall not pass');
+            expect(res.header['access-control-allow-credentials']).to.be(undefined);
+            expect(res.header['access-control-allow-origin']).to.be(undefined);
+            done();
+          });
+      });
+    });
   });
 
   describe('handshake', function () {


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

When `allowRequest` option is provided and fails for a request (for example when checking the allowed origins in `socket.io`), the client receives:

```
400 Bad Request
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: http://b.local /* but only a.local is allowed */
```

### New behaviour

The client will now receive a 403 response, without CORS headers.

### Other information (e.g. related issues)

Closes https://github.com/socketio/engine.io/issues/449
Related:  #211 & #281



