### PR TITLE
Change UNKNOWN_TRANSPORT value

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -87,14 +87,14 @@ function Server (opts) {
  */
 
 Server.errors = {
-  UNKNOWN_TRANSPORT: 0,
+  UNKNOWN_TRANSPORT: 1000,
   UNKNOWN_SID: 1,
   BAD_HANDSHAKE_METHOD: 2,
   BAD_REQUEST: 3
 };
 
 Server.errorMessages = {
-  0: 'Transport unknown',
+  1000: 'Transport unknown',
   1: 'Session ID unknown',
   2: 'Bad handshake method',
   3: 'Bad request'


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
With "unknown transport" error 
`if (err)`
leads to negative, but we have error.

### New behaviour
UNKNOWN_TRANSPORT value replace to 1000

### Other information (e.g. related issues)



Change UNKNOWN_TRANSPORT enum value from 0 to 1000.
Because zero is an unsafe value for conditional expressions:
if (err) => if (0)