### PR TITLE
Add proper response when handleUpgrade fails

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -329,8 +329,8 @@ Server.prototype.handleUpgrade = function (req, socket, upgradeHead) {
 
   var self = this;
   this.verify(req, true, function (err, success) {
-    if (err) {
-      socket.end();
+    if (!success) {
+      abortConnection(socket, err);
       return;
     }
 
@@ -463,3 +463,27 @@ Server.prototype.attach = function (server, options) {
     });
   }
 };
+
+/**
+ * Close the connection
+ *
+ * @param {net.Socket} socket
+ * @param {code} error code
+ * @api private
+ */
+
+function abortConnection (socket, code) {
+  if (socket.writable) {
+    var message = Server.errorMessages.hasOwnProperty(code) ? Server.errorMessages[code] : code;
+    var length = Buffer.byteLength(message);
+    socket.write(
+      'HTTP/1.1 400 Bad Request\r\n' +
+      'Connection: close\r\n' +
+      'Content-type: text/html\r\n' +
+      'Content-Length: ' + length + '\r\n' +
+      '\r\n' +
+      message
+    );
+  }
+  socket.destroy();
+}

--- a/lib/server.js
+++ b/lib/server.js
@@ -465,7 +465,7 @@ Server.prototype.attach = function (server, options) {
 };
 
 /**
- * Close the connection
+ * Closes the connection
  *
  * @param {net.Socket} socket
  * @param {code} error code


### PR DESCRIPTION
### The kind of change this PR does introduce

* **a bug fix**

### Current behaviour

When the `verify` method fails, the current implementation closes the connection immediately, which is understood by some proxy (such as nginx) as if the server was not available (resulting in "upstream
prematurely closed connection while reading response header from upstream" error).

### New behaviour

That commit make sure a proper response is sent before closing the connection.

### Other information (e.g. related issues)

Fixes https://github.com/socketio/engine.io/issues/283
Closes https://github.com/socketio/engine.io/pull/454, fixes https://github.com/socketio/socket.io/issues/2779

