### PR TITLE
Add an `initialPacket` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ to a single process.
         Set false to not save io cookie on all requests. (`/`)
       - `cookieHttpOnly` (`Boolean`): If `true` HttpOnly io cookie cannot be accessed by client-side APIs, such as JavaScript. (`true`) _This option has no effect if `cookie` or `cookiePath` is set to `false`._
       - `wsEngine` (`String`): what WebSocket server implementation to use. Specified module must conform to the `ws` interface (see [ws module api docs](https://github.com/websockets/ws/blob/master/doc/ws.md)). Default value is `ws`. An alternative c++ addon is also available by installing `uws` module.
-      - `initialMessage` (`Object`): an optional packet which will be concatenated to the handshake packet emitted by Engine.IO.
+      - `initialPacket` (`Object`): an optional packet which will be concatenated to the handshake packet emitted by Engine.IO.
 - `close`
     - Closes all clients
     - **Returns** `Server` for chaining

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ to a single process.
         Set false to not save io cookie on all requests. (`/`)
       - `cookieHttpOnly` (`Boolean`): If `true` HttpOnly io cookie cannot be accessed by client-side APIs, such as JavaScript. (`true`) _This option has no effect if `cookie` or `cookiePath` is set to `false`._
       - `wsEngine` (`String`): what WebSocket server implementation to use. Specified module must conform to the `ws` interface (see [ws module api docs](https://github.com/websockets/ws/blob/master/doc/ws.md)). Default value is `ws`. An alternative c++ addon is also available by installing `uws` module.
+      - `additionalHandshakePacket` (`Object`): an optional packet which will be concatenated to the handshake packet emitted by Engine.IO.
 - `close`
     - Closes all clients
     - **Returns** `Server` for chaining

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ to a single process.
         Set false to not save io cookie on all requests. (`/`)
       - `cookieHttpOnly` (`Boolean`): If `true` HttpOnly io cookie cannot be accessed by client-side APIs, such as JavaScript. (`true`) _This option has no effect if `cookie` or `cookiePath` is set to `false`._
       - `wsEngine` (`String`): what WebSocket server implementation to use. Specified module must conform to the `ws` interface (see [ws module api docs](https://github.com/websockets/ws/blob/master/doc/ws.md)). Default value is `ws`. An alternative c++ addon is also available by installing `uws` module.
-      - `additionalHandshakePacket` (`Object`): an optional packet which will be concatenated to the handshake packet emitted by Engine.IO.
+      - `initialMessage` (`Object`): an optional packet which will be concatenated to the handshake packet emitted by Engine.IO.
 - `close`
     - Closes all clients
     - **Returns** `Server` for chaining

--- a/lib/server.js
+++ b/lib/server.js
@@ -49,7 +49,7 @@ function Server (opts) {
   this.cookieHttpOnly = false !== opts.cookieHttpOnly;
   this.perMessageDeflate = false !== opts.perMessageDeflate ? (opts.perMessageDeflate || true) : false;
   this.httpCompression = false !== opts.httpCompression ? (opts.httpCompression || {}) : false;
-  this.additionalHandshakePacket = opts.additionalHandshakePacket;
+  this.initialMessage = opts.initialMessage;
 
   var self = this;
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -49,7 +49,7 @@ function Server (opts) {
   this.cookieHttpOnly = false !== opts.cookieHttpOnly;
   this.perMessageDeflate = false !== opts.perMessageDeflate ? (opts.perMessageDeflate || true) : false;
   this.httpCompression = false !== opts.httpCompression ? (opts.httpCompression || {}) : false;
-  this.initialMessage = opts.initialMessage;
+  this.initialPacket = opts.initialPacket;
 
   var self = this;
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -49,6 +49,7 @@ function Server (opts) {
   this.cookieHttpOnly = false !== opts.cookieHttpOnly;
   this.perMessageDeflate = false !== opts.perMessageDeflate ? (opts.perMessageDeflate || true) : false;
   this.httpCompression = false !== opts.httpCompression ? (opts.httpCompression || {}) : false;
+  this.additionalHandshakePacket = opts.additionalHandshakePacket;
 
   var self = this;
 

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -65,8 +65,8 @@ Socket.prototype.onOpen = function () {
     pingTimeout: this.server.pingTimeout
   }));
 
-  if (this.server.additionalHandshakePacket) {
-    this.sendPacket('message', this.server.additionalHandshakePacket);
+  if (this.server.initialMessage) {
+    this.sendPacket('message', this.server.initialMessage);
   }
 
   this.emit('open');

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -65,8 +65,8 @@ Socket.prototype.onOpen = function () {
     pingTimeout: this.server.pingTimeout
   }));
 
-  if (this.server.initialMessage) {
-    this.sendPacket('message', this.server.initialMessage);
+  if (this.server.initialPacket) {
+    this.sendPacket('message', this.server.initialPacket);
   }
 
   this.emit('open');

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -65,6 +65,10 @@ Socket.prototype.onOpen = function () {
     pingTimeout: this.server.pingTimeout
   }));
 
+  if (this.server.additionalHandshakePacket) {
+    this.sendPacket('message', this.server.additionalHandshakePacket);
+  }
+
   this.emit('open');
   this.setPingTimeout();
 };

--- a/test/server.js
+++ b/test/server.js
@@ -397,6 +397,18 @@ describe('server', function () {
           });
       });
     });
+
+    it('should send a packet along with the handshake', function (done) {
+      listen({ additionalHandshakePacket: 'faster!' }, function (port) {
+        var socket = new eioc.Socket('ws://localhost:%d'.s(port));
+        socket.on('open', function () {
+          socket.on('message', function (msg) {
+            expect(msg).to.be('faster!');
+            done();
+          });
+        });
+      });
+    });
   });
 
   describe('close', function () {
@@ -485,7 +497,7 @@ describe('server', function () {
     });
 
     it('should trigger on both ends upon ping timeout', function (done) {
-      var opts = { allowUpgrades: false, pingTimeout: 500, pingInterval: 10 };
+      var opts = { allowUpgrades: false, pingTimeout: 50, pingInterval: 50 };
       var engine = listen(opts, function (port) {
         var socket = new eioc.Socket('ws://localhost:%d'.s(port));
         var total = 2;

--- a/test/server.js
+++ b/test/server.js
@@ -399,7 +399,7 @@ describe('server', function () {
     });
 
     it('should send a packet along with the handshake', function (done) {
-      listen({ additionalHandshakePacket: 'faster!' }, function (port) {
+      listen({ initialMessage: 'faster!' }, function (port) {
         var socket = new eioc.Socket('ws://localhost:%d'.s(port));
         socket.on('open', function () {
           socket.on('message', function (msg) {

--- a/test/server.js
+++ b/test/server.js
@@ -399,7 +399,7 @@ describe('server', function () {
     });
 
     it('should send a packet along with the handshake', function (done) {
-      listen({ initialMessage: 'faster!' }, function (port) {
+      listen({ initialPacket: 'faster!' }, function (port) {
         var socket = new eioc.Socket('ws://localhost:%d'.s(port));
         socket.on('open', function () {
           socket.on('message', function (msg) {


### PR DESCRIPTION
### The kind of change this PR does introduce

* a new feature

### New behaviour

This PR adds a new option, `initialMessage`, which allow to provide a packet that will be concatenated with the handshake packet. That will allow to merge Engine.IO (sent [here](https://github.com/socketio/engine.io/blob/1.8.2/lib/socket.js#L61)) and Socket.IO (sent [here](https://github.com/socketio/socket.io/blob/1.7.2/lib/socket.js#L296)) handshakes, in order to reduce the number of roundtrips necessary to establish a connection.

Reviews are welcome! (and if you have a better name for the option...)
