### PR TITLE
Initialize the WebSocket server in the `Server` constructor

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -61,6 +61,8 @@ function Server (opts) {
       compression.threshold = 1024;
     }
   });
+
+  this.init();
 }
 
 /**
@@ -104,23 +106,24 @@ Server.prototype.clients;
  */
 
 Server.prototype.init = function () {
-  if (~this.transports.indexOf('websocket')) {
-    var wsModule;
-    try {
-      wsModule = require(this.wsEngine);
-    } catch (ex) {
-      this.wsEngine = 'ws';
-      // keep require('ws') as separate expression for packers (browserify, etc)
-      wsModule = require('ws');
-    }
-    var WebSocketServer = wsModule.Server;
-    this.ws = new WebSocketServer({
-      noServer: true,
-      clientTracking: false,
-      perMessageDeflate: this.perMessageDeflate,
-      maxPayload: this.maxHttpBufferSize
-    });
+  if (!~this.transports.indexOf('websocket')) return;
+
+  if (this.ws) this.ws.close();
+
+  var wsModule;
+  try {
+    wsModule = require(this.wsEngine);
+  } catch (ex) {
+    this.wsEngine = 'ws';
+    // keep require('ws') as separate expression for packers (browserify, etc)
+    wsModule = require('ws');
   }
+  this.ws = new wsModule.Server({
+    noServer: true,
+    clientTracking: false,
+    perMessageDeflate: this.perMessageDeflate,
+    maxPayload: this.maxHttpBufferSize
+  });
 };
 
 /**

--- a/test/engine.io.js
+++ b/test/engine.io.js
@@ -29,6 +29,7 @@ describe('engine', function () {
     it('should create a Server when require called with no arguments', function () {
       var engine = eio();
       expect(engine).to.be.an(eio.Server);
+      expect(engine.ws).to.be.ok();
     });
   });
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

Described in #473.

### New behaviour

Makes a plain Engine.IO server, not bound to any HTTP server, work again.

### Other information (e.g. related issues)

Fixes #473.
It should also fix cases where an already listening server is used which is currently equally broken.

```js
'use strict';

const eioc = require('engine.io-client');
const eio = require('engine.io');
const http = require('http');

const server = http.createServer();

server.listen(3000, () => {
  const engine = eio.attach(server);

  engine.on('connection', (socket) => {
    socket.on('message', (data) => socket.send(data));
    socket.on('close', () => console.log('close'));
  });

  const socket = eioc('http://localhost:3000');

  socket.on('open', () => socket.send('foo'));
  socket.on('message', (data) => console.log(data));
  socket.on('close', () => console.log('close'));
});
```
