### PR TITLE
Add an option to toggle handling of OPTIONS requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ to a single process.
       - `path` (`String`): name of the path to capture (`/engine.io`).
       - `destroyUpgrade` (`Boolean`): destroy unhandled upgrade requests (`true`)
       - `destroyUpgradeTimeout` (`Number`): milliseconds after which unhandled requests are ended (`1000`)
+      - `enableOptions` (`Boolean`): let engine.io handle the OPTIONS requests (`true`)
 - `generateId`
     - Generate a socket id.
     - Overwrite this method to generate your custom socket id.

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ to a single process.
       - `path` (`String`): name of the path to capture (`/engine.io`).
       - `destroyUpgrade` (`Boolean`): destroy unhandled upgrade requests (`true`)
       - `destroyUpgradeTimeout` (`Number`): milliseconds after which unhandled requests are ended (`1000`)
-      - `enableOptions` (`Boolean`): let engine.io handle the OPTIONS requests (`true`)
+      - `handlePreflightRequest` (`Boolean|Function`): let engine.io handle the OPTIONS requests. You can also pass a custom function to handle the requests (`true`)
 - `generateId`
     - Generate a socket id.
     - Overwrite this method to generate your custom socket id.

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ to a single process.
       - `path` (`String`): name of the path to capture (`/engine.io`).
       - `destroyUpgrade` (`Boolean`): destroy unhandled upgrade requests (`true`)
       - `destroyUpgradeTimeout` (`Number`): milliseconds after which unhandled requests are ended (`1000`)
-      - `handlePreflightRequest` (`Boolean|Function`): let engine.io handle the OPTIONS requests. You can also pass a custom function to handle the requests (`true`)
+      - `handlePreflightRequest` (`Boolean|Function`): whether to let engine.io handle the OPTIONS requests. You can also pass a custom function to handle the requests (`true`)
 - `generateId`
     - Generate a socket id.
     - Overwrite this method to generate your custom socket id.

--- a/lib/server.js
+++ b/lib/server.js
@@ -417,6 +417,9 @@ Server.prototype.attach = function (server, options) {
   path += '/';
 
   function check (req) {
+    if ('OPTIONS' === req.method && false === options.enableOptions) {
+      return false;
+    }
     return path === req.url.substr(0, path.length);
   }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -417,7 +417,7 @@ Server.prototype.attach = function (server, options) {
   path += '/';
 
   function check (req) {
-    if ('OPTIONS' === req.method && false === options.enableOptions) {
+    if ('OPTIONS' === req.method && false === options.handlePreflightRequest) {
       return false;
     }
     return path === req.url.substr(0, path.length);
@@ -432,7 +432,11 @@ Server.prototype.attach = function (server, options) {
   server.on('request', function (req, res) {
     if (check(req)) {
       debug('intercepting request for path "%s"', path);
-      self.handleRequest(req, res);
+      if ('OPTIONS' === req.method && 'function' === typeof options.handlePreflightRequest) {
+        options.handlePreflightRequest.call(server, req, res);
+      } else {
+        self.handleRequest(req, res);
+      }
     } else {
       for (var i = 0, l = listeners.length; i < l; i++) {
         listeners[i].call(server, req, res);

--- a/test/server.js
+++ b/test/server.js
@@ -2514,6 +2514,67 @@ describe('server', function () {
     });
   });
 
+  describe('cors', function () {
+    it('should handle OPTIONS requests', function (done) {
+      listen({handlePreflightRequest: true}, function (port) {
+        request.options('http://localhost:%d/engine.io/default/'.s(port))
+          .set('Origin', 'http://engine.io')
+          .query({ transport: 'polling' })
+          .end(function (res) {
+            expect(res.status).to.be(400);
+            expect(res.body.code).to.be(2);
+            expect(res.body.message).to.be('Bad handshake method');
+            expect(res.header['access-control-allow-credentials']).to.be('true');
+            expect(res.header['access-control-allow-origin']).to.be('http://engine.io');
+            done();
+          });
+      });
+    });
+
+    it('should not handle OPTIONS requests', function (done) {
+      listen({handlePreflightRequest: false}, function (port) {
+        request.options('http://localhost:%d/engine.io/default/'.s(port))
+          .set('Origin', 'http://engine.io')
+          .query({ transport: 'polling' })
+          .end(function (res) {
+            expect(res.status).to.be(501);
+            expect(res.body.code).to.be(undefined);
+            done();
+          });
+      });
+    });
+
+    it('should handle OPTIONS requests with the given function', function (done) {
+      const handlePreflightRequest = (req, res) => {
+        let headers = {};
+        if (req.headers.origin) {
+          headers['Access-Control-Allow-Credentials'] = 'true';
+          headers['Access-Control-Allow-Origin'] = req.headers.origin;
+        } else {
+          headers['Access-Control-Allow-Origin'] = '*';
+        }
+        headers['Access-Control-Allow-Methods'] = 'GET,HEAD,PUT,PATCH,POST,DELETE';
+        headers['Access-Control-Allow-Headers'] = 'origin, content-type, accept';
+        res.writeHead(200, headers);
+        res.end();
+      };
+      listen({handlePreflightRequest}, function (port) {
+        request.options('http://localhost:%d/engine.io/default/'.s(port))
+          .set('Origin', 'http://engine.io')
+          .query({ transport: 'polling' })
+          .end(function (res) {
+            expect(res.status).to.be(200);
+            expect(res.body).to.be.empty();
+            expect(res.header['access-control-allow-credentials']).to.be('true');
+            expect(res.header['access-control-allow-origin']).to.be('http://engine.io');
+            expect(res.header['access-control-allow-methods']).to.be('GET,HEAD,PUT,PATCH,POST,DELETE');
+            expect(res.header['access-control-allow-headers']).to.be('origin, content-type, accept');
+            done();
+          });
+      });
+    });
+  });
+
   if (!UWS_ENGINE && parseInt(process.versions.node, 10) >= 4) {
     describe('wsEngine option', function () {
       it('should allow loading of other websocket server implementation like uws', function (done) {

--- a/test/server.js
+++ b/test/server.js
@@ -2545,8 +2545,8 @@ describe('server', function () {
     });
 
     it('should handle OPTIONS requests with the given function', function (done) {
-      const handlePreflightRequest = (req, res) => {
-        let headers = {};
+      var handlePreflightRequest = function (req, res) {
+        var headers = {};
         if (req.headers.origin) {
           headers['Access-Control-Allow-Credentials'] = 'true';
           headers['Access-Control-Allow-Origin'] = req.headers.origin;


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

OPTIONS request are processed by engine.io

### New behaviour

By setting `enableOptions` to `false`, OPTIONS request are no longer processed by engine.io

### Other information (e.g. related issues)

Related to #279

This allows to handle CORS ourselves:
```js
var app = require('express')();
var cors = require('cors');
app.options('*', cors());
var server = require('http').Server(app);
var io = require('socket.io')(server, {
  enableOptions: false
});
io.on('connection', function(){ /* … */ });
server.listen(3000);
```

I've raised the PR against the 1.8.x branch, as it's the version used by socket.io at the moment.
