### PR TITLE
Adding async-await for generateId function

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -291,9 +291,7 @@ Server.prototype.generateId = function (req) {
  */
 
 Server.prototype.handshake = function (transportName, req) {
-
   this.generateId(req, function (id) {
-
     debug('handshaking client "%s"', id);
 
     try {

--- a/lib/server.js
+++ b/lib/server.js
@@ -291,16 +291,18 @@ Server.prototype.generateId = function (req, done) {
  */
 
 Server.prototype.handshake = function (transportName, req) {
+  var self = this;
+  var this_ = this;
   this.generateId(req, function (id) {
     debug('handshaking client "%s"', id);
 
     try {
       var transport = new transports[transportName](req);
       if ('polling' === transportName) {
-        transport.maxHttpBufferSize = this.maxHttpBufferSize;
-        transport.httpCompression = this.httpCompression;
+        transport.maxHttpBufferSize = this_.maxHttpBufferSize;
+        transport.httpCompression = this_.httpCompression;
       } else if ('websocket' === transportName) {
-        transport.perMessageDeflate = this.perMessageDeflate;
+        transport.perMessageDeflate = this_.perMessageDeflate;
       }
 
       if (req._query && req._query.b64) {
@@ -312,8 +314,7 @@ Server.prototype.handshake = function (transportName, req) {
       sendErrorMessage(req, req.res, Server.errors.BAD_REQUEST);
       return;
     }
-    var socket = new Socket(id, this, transport, req);
-    var self = this;
+    var socket = new Socket(id, this_, transport, req);
 
     if (false !== this.cookie) {
       transport.on('headers', function (headers) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -278,8 +278,8 @@ function sendErrorMessage (req, res, code) {
  * @api public
  */
 
-Server.prototype.generateId = function (req) {
-  return base64id.generateId();
+Server.prototype.generateId = function (req, done) {
+  done(base64id.generateId());
 };
 
 /**

--- a/lib/server.js
+++ b/lib/server.js
@@ -290,53 +290,54 @@ Server.prototype.generateId = function (req) {
  * @api private
  */
 
-Server.prototype.handshake = async function (transportName, req) {
-  var id = await this.generateId(req);
+Server.prototype.handshake = function (transportName, req) {
+  this.generateId(req, function(id) {
 
-  debug('handshaking client "%s"', id);
+    debug('handshaking client "%s"', id);
 
-  try {
-    var transport = new transports[transportName](req);
-    if ('polling' === transportName) {
-      transport.maxHttpBufferSize = this.maxHttpBufferSize;
-      transport.httpCompression = this.httpCompression;
-    } else if ('websocket' === transportName) {
-      transport.perMessageDeflate = this.perMessageDeflate;
+    try {
+      var transport = new transports[transportName](req);
+      if ('polling' === transportName) {
+        transport.maxHttpBufferSize = this.maxHttpBufferSize;
+        transport.httpCompression = this.httpCompression;
+      } else if ('websocket' === transportName) {
+        transport.perMessageDeflate = this.perMessageDeflate;
+      }
+
+      if (req._query && req._query.b64) {
+        transport.supportsBinary = false;
+      } else {
+        transport.supportsBinary = true;
+      }
+    } catch (e) {
+      sendErrorMessage(req, req.res, Server.errors.BAD_REQUEST);
+      return;
+    }
+    var socket = new Socket(id, this, transport, req);
+    var self = this;
+
+    if (false !== this.cookie) {
+      transport.on('headers', function (headers) {
+        headers['Set-Cookie'] = cookieMod.serialize(self.cookie, id,
+          {
+            path: self.cookiePath,
+            httpOnly: self.cookiePath ? self.cookieHttpOnly : false
+          });
+      });
     }
 
-    if (req._query && req._query.b64) {
-      transport.supportsBinary = false;
-    } else {
-      transport.supportsBinary = true;
-    }
-  } catch (e) {
-    sendErrorMessage(req, req.res, Server.errors.BAD_REQUEST);
-    return;
-  }
-  var socket = new Socket(id, this, transport, req);
-  var self = this;
+    transport.onRequest(req);
 
-  if (false !== this.cookie) {
-    transport.on('headers', function (headers) {
-      headers['Set-Cookie'] = cookieMod.serialize(self.cookie, id,
-        {
-          path: self.cookiePath,
-          httpOnly: self.cookiePath ? self.cookieHttpOnly : false
-        });
+    this.clients[id] = socket;
+    this.clientsCount++;
+
+    socket.once('close', function () {
+      delete self.clients[id];
+      self.clientsCount--;
     });
-  }
 
-  transport.onRequest(req);
-
-  this.clients[id] = socket;
-  this.clientsCount++;
-
-  socket.once('close', function () {
-    delete self.clients[id];
-    self.clientsCount--;
+    this.emit('connection', socket);
   });
-
-  this.emit('connection', socket);
 };
 
 /**

--- a/lib/server.js
+++ b/lib/server.js
@@ -291,7 +291,8 @@ Server.prototype.generateId = function (req) {
  */
 
 Server.prototype.handshake = function (transportName, req) {
-  this.generateId(req, function(id) {
+
+  this.generateId(req, function (id) {
 
     debug('handshaking client "%s"', id);
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -290,8 +290,8 @@ Server.prototype.generateId = function (req) {
  * @api private
  */
 
-Server.prototype.handshake = function (transportName, req) {
-  var id = this.generateId(req);
+Server.prototype.handshake = async function (transportName, req) {
+  var id = await this.generateId(req);
 
   debug('handshaking client "%s"', id);
 


### PR DESCRIPTION
When providing an Id from an in-memory database, accessing the database over the network and getting the id may cause to skip `id` assignment. 

In this case id will be `undefined`. Because of this reason engine.io fall into an endless loop.
To overcome this issue async-await combination can be used. 



### The kind of change this PR does introduce

* [x] a new feature
* [ ] a bug fix
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
`generateId` may be skipped as `undefined` because of id generating operations.

### New behaviour
By using `await` option, `handshake` method can be waited to complete `generateId()` function.

### Other information (e.g. related issues)
However, `async-await` combination doesn't work on former Node.js versions.

