### PR TITLE
1.8.x: Upgrade to `ws@1.1.4`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "base64id": "1.0.0",
     "debug": "2.3.3",
     "engine.io-parser": "1.3.2",
-    "ws": "1.1.2",
+    "ws": "1.1.4",
     "cookie": "0.3.1"
   },
   "devDependencies": {
@@ -47,7 +47,7 @@
     "mocha": "2.3.4",
     "s": "0.1.1",
     "superagent": "0.15.4",
-    "uws": "0.4.0"
+    "uws": "0.14.1"
   },
   "scripts": {
     "test": "gulp test; EIO_WS_ENGINE=uws gulp test;"


### PR DESCRIPTION
This PR fixes a bug with a clean install of a server using `socket.io`; the underlying cause was fixed in `ws`.

Current behavior: The connection can not be established due to a bug when using `bufferUtil`.

The bug is described here: https://github.com/websockets/ws/issues/1010