### PR TITLE
add test for maxHttpBufferSize option with websocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ to a single process.
         packet (`25000`)
       - `upgradeTimeout` (`Number`): how many ms before an uncompleted transport upgrade is cancelled (`10000`)
       - `maxHttpBufferSize` (`Number`): how many bytes or characters a message
-        can be when polling, before closing the session (to avoid DoS). Default
+        can be, before closing the session (to avoid DoS). Default
         value is `10E7`.
       - `allowRequest` (`Function`): A function that receives a given handshake
         or upgrade request as its first parameter, and can decide whether to

--- a/test/server.js
+++ b/test/server.js
@@ -1153,6 +1153,22 @@ describe('server', function () {
       setTimeout(done, 1000);
     });
 
+    it('should not be receiving data when getting a message longer than maxHttpBufferSize (websocket)', function (done) {
+      var opts = { maxHttpBufferSize: 5 };
+      var engine = listen(opts, function (port) {
+        var socket = new eioc.Socket('ws://localhost:%d'.s(port), { transports: ['websocket'] });
+        engine.on('connection', function (conn) {
+          conn.on('message', function (msg) {
+            done(new Error('Test invalidation (message is longer than allowed)'));
+          });
+        });
+        socket.on('open', function () {
+          socket.send('aasdasdakjhasdkjhasdkjhasdkjhasdkjhasdkjhasdkjha');
+        });
+      });
+      setTimeout(done, 1000);
+    });
+
     it('should receive data when getting a message shorter than maxHttpBufferSize when polling', function (done) {
       var opts = { allowUpgrades: false, transports: ['polling'], maxHttpBufferSize: 5 };
       var engine = listen(opts, function (port) {

--- a/test/server.js
+++ b/test/server.js
@@ -1143,14 +1143,16 @@ describe('server', function () {
         var socket = new eioc.Socket('ws://localhost:%d'.s(port));
         engine.on('connection', function (conn) {
           conn.on('message', function (msg) {
-            console.log(msg);
+            done(new Error('Test invalidation (message is longer than allowed)'));
           });
         });
         socket.on('open', function () {
           socket.send('aasdasdakjhasdkjhasdkjhasdkjhasdkjhasdkjhasdkjha');
         });
+        socket.on('close', function () {
+          done();
+        });
       });
-      setTimeout(done, 1000);
     });
 
     it('should not be receiving data when getting a message longer than maxHttpBufferSize (websocket)', function (done) {
@@ -1165,8 +1167,10 @@ describe('server', function () {
         socket.on('open', function () {
           socket.send('aasdasdakjhasdkjhasdkjhasdkjhasdkjhasdkjhasdkjha');
         });
+        socket.on('close', function () {
+          done();
+        });
       });
-      setTimeout(done, 1000);
     });
 
     it('should receive data when getting a message shorter than maxHttpBufferSize when polling', function (done) {


### PR DESCRIPTION
Since https://github.com/socketio/engine.io/commit/17ec2150c00e3e0e68fa6a490f940c2f4c8f11bc, `maxHttpBufferSize` also applies to websocket transport.

Related: https://github.com/socketio/engine.io/issues/475