### PR TITLE
Bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   "dependencies": {
     "accepts": "1.3.3",
     "base64id": "1.0.0",
-    "debug": "2.3.3",
-    "engine.io-parser": "2.0.3",
-    "ws": "2.2.3",
+    "debug": "~2.6.4",
+    "engine.io-parser": "~2.1.0",
+    "ws": "~2.3.1",
     "cookie": "0.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
- debug to version 2.6.4
- engine.io-parser to version 2.1.0
- ws to version 2.3.1

