### PR TITLE
Fix null payload when aborting connection

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -503,7 +503,7 @@ Server.prototype.attach = function (server, options) {
 
 function abortConnection (socket, code) {
   if (socket.writable) {
-    var message = Server.errorMessages.hasOwnProperty(code) ? Server.errorMessages[code] : code;
+    var message = Server.errorMessages.hasOwnProperty(code) ? Server.errorMessages[code] : (code || '');
     var length = Buffer.byteLength(message);
     socket.write(
       'HTTP/1.1 400 Bad Request\r\n' +

--- a/test/server.js
+++ b/test/server.js
@@ -92,6 +92,15 @@ describe('server', function () {
           });
       });
     });
+
+    it('should disallow connection that are rejected by `allowRequest`', function (done) {
+      listen({ allowRequest: function (req, fn) { fn(null, false); } }, function (port) {
+        var client = eioc('ws://localhost:%d'.s(port), { transports: ['websocket'] });
+        client.on('error', function () {
+          done();
+        });
+      });
+    });
   });
 
   describe('handshake', function () {


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

`Buffer.byteLength` chokes on node v7 (https://github.com/nodejs/node/wiki/Breaking-changes-between-v6-and-v7#buffer) when not provided with a String (which is what happened in socket.io [checkRequest](https://github.com/socketio/socket.io/blob/1.7.3/lib/index.js#L62)).

### New behaviour


### Other information (e.g. related issues)

Fixes https://github.com/socketio/engine.io/issues/502
