### PR TITLE
[feat] make socket candidate id available in allowRequest callback through req

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -220,6 +220,7 @@ Server.prototype.handleRequest = function (req, res) {
   debug('handling "%s" http request "%s"', req.method, req.url);
   this.prepare(req);
   req.res = res;
+  req.idCandidate = this.generateId(req);
 
   var self = this;
   this.verify(req, false, function (err, success) {
@@ -291,7 +292,7 @@ Server.prototype.generateId = function (req) {
  */
 
 Server.prototype.handshake = function (transportName, req) {
-  var id = this.generateId(req);
+  var id = req.idCandidate;
 
   debug('handshaking client "%s"', id);
 


### PR DESCRIPTION



### The kind of change this PR does introduce
* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
The socket id is generated inside the `handshake` method, if the `verify` method is successful.

### New behaviour
A candidate for the socket id is generated in the `handleRequest` method, and that id candidate is used in the `handshake` method, if the `verify` method is successful. Now inside the `verify` method we have access to the id that will be assigned to the socket.

### Other information (e.g. related issues)
Fixes #505

