### PR TITLE
support WebPack, changed Server.prototype.init so defaults have static require statements

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -112,20 +112,11 @@ Server.prototype.init = function () {
 
   var wsModule;
   try {
-    // support WebPack with static require(s) if possible...
-    switch(this.wsEngine) {
-        case 'uws':
-            wsModule = require('uws');
-        break;
-
-        case 'ws':
-            wsModule = require('ws');
-        break;
-       // only this case breaks the ability to WebPack engine.io, warning can be safely ignored
-        default:
-            wsModule = require(this.wsEngine);          
+    switch (this.wsEngine) {
+      case 'uws': wsModule = require('uws'); break;
+      case 'ws': wsModule = require('ws'); break;
+      default: throw new Error('unknown wsEngine');
     }
-    
   } catch (ex) {
     this.wsEngine = 'ws';
     // keep require('ws') as separate expression for packers (browserify, etc)

--- a/lib/server.js
+++ b/lib/server.js
@@ -112,7 +112,20 @@ Server.prototype.init = function () {
 
   var wsModule;
   try {
-    wsModule = require(this.wsEngine);
+    // support WebPack with static require(s) if possible...
+    switch(this.wsEngine) {
+        case 'uws':
+            wsModule = require('uws');
+        break;
+
+        case 'ws':
+            wsModule = require('ws');
+        break;
+       // only this case breaks the ability to WebPack engine.io, warning can be safely ignored
+        default:
+            wsModule = require(this.wsEngine);          
+    }
+    
   } catch (ex) {
     this.wsEngine = 'ws';
     // keep require('ws') as separate expression for packers (browserify, etc)


### PR DESCRIPTION



### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
WebPack does not support variables in require statements.  In this case it seems as though the two defaults ws, uws, are probably sufficient for most use cases.  These can be expressed as static require statements.

### New behaviour
Supports default ws libs with static requires statements.

### Other information (e.g. related issues)


