### PR TITLE
Fix readme wsEngine default

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ to a single process.
         option. If false, no path will be sent, which means browsers will only send the cookie on the engine.io attached path (`/engine.io`).
         Set false to not save io cookie on all requests. (`/`)
       - `cookieHttpOnly` (`Boolean`): If `true` HttpOnly io cookie cannot be accessed by client-side APIs, such as JavaScript. (`true`) _This option has no effect if `cookie` or `cookiePath` is set to `false`._
-      - `wsEngine` (`String`): what WebSocket server implementation to use. Specified module must conform to the `ws` interface (see [ws module api docs](https://github.com/websockets/ws/blob/master/doc/ws.md)). Default value is `ws`. An alternative c++ addon is also available by installing `uws` module.
+      - `wsEngine` (`String`): what WebSocket server implementation to use. Specified module must conform to the `ws` interface (see [ws module api docs](https://github.com/websockets/ws/blob/master/doc/ws.md)). Default value is `uws` (see [µWebSockets](https://github.com/uWebSockets/uWebSockets)).
       - `initialPacket` (`Object`): an optional packet which will be concatenated to the handshake packet emitted by Engine.IO.
 - `close`
     - Closes all clients


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

Merge #459 (release 2.0.0) changed default wsEngine to uws. Updating readme to reflect this change.
