### PR TITLE
[fix] Undeterministic error in polling buffer processing

### DIFF
--- a/lib/transports/polling.js
+++ b/lib/transports/polling.js
@@ -140,11 +140,10 @@ Polling.prototype.onDataRequest = function (req, res) {
   var self = this;
 
   function cleanup () {
-    chunks = isBinary ? new Buffer(0) : '';
     req.removeListener('data', onData);
     req.removeListener('end', onEnd);
     req.removeListener('close', onClose);
-    self.dataReq = self.dataRes = null;
+    self.dataReq = self.dataRes = chunks = null;
   }
 
   function onClose () {
@@ -163,7 +162,7 @@ Polling.prototype.onDataRequest = function (req, res) {
     }
 
     if (contentLength > self.maxHttpBufferSize) {
-      chunks = '';
+      chunks = isBinary ? new Buffer(0) : '';
       req.connection.destroy();
     }
   }


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

Sometimes chunks stops being a Buffer when onData expects it to be one

### New behaviour

Ensure all assignments for chunks are Buffer when they should, even when onData is supposed to not be called again.

### Other information (e.g. related issues)

#528 for details
