### PR TITLE
fix undefined remoteAddress when using uws

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -31,7 +31,11 @@ function Socket (id, server, transport, req) {
   this.request = req;
 
   // Cache IP since it might not be in the req later
-  this.remoteAddress = req.connection.remoteAddress;
+  if (req.websocket && req.websocket._socket) {
+    this.remoteAddress = req.websocket._socket.remoteAddress;
+  } else {
+    this.remoteAddress = req.connection.remoteAddress;
+  }
 
   this.checkIntervalTimer = null;
   this.upgradeTimeoutTimer = null;

--- a/test/server.js
+++ b/test/server.js
@@ -2654,7 +2654,7 @@ describe('server', function () {
 
   describe('remoteAddress', function () {
     it('should be defined (polling)', function (done) {
-      let engine = listen({ transports: ['polling'] }, port => {
+      var engine = listen({ transports: ['polling'] }, port => {
         eioc('ws://localhost:%d'.s(port), { transports: ['polling'] });
         engine.on('connection', socket => {
           expect(socket.remoteAddress).to.be('::ffff:127.0.0.1');
@@ -2664,7 +2664,7 @@ describe('server', function () {
     });
 
     it('should be defined (ws)', function (done) {
-      let engine = listen({ transports: ['websocket'] }, port => {
+      var engine = listen({ transports: ['websocket'] }, port => {
         eioc('ws://localhost:%d'.s(port), { transports: ['websocket'] });
         engine.on('connection', socket => {
           expect(socket.remoteAddress).to.be('::ffff:127.0.0.1');

--- a/test/server.js
+++ b/test/server.js
@@ -2651,4 +2651,26 @@ describe('server', function () {
       });
     });
   });
+
+  describe('remoteAddress', function () {
+    it('should be defined (polling)', function (done) {
+      let engine = listen({ transports: ['polling'] }, port => {
+        eioc('ws://localhost:%d'.s(port), { transports: ['polling'] });
+        engine.on('connection', socket => {
+          expect(socket.remoteAddress).to.be('::ffff:127.0.0.1');
+          done();
+        });
+      });
+    });
+
+    it('should be defined (ws)', function (done) {
+      let engine = listen({ transports: ['websocket'] }, port => {
+        eioc('ws://localhost:%d'.s(port), { transports: ['websocket'] });
+        engine.on('connection', socket => {
+          expect(socket.remoteAddress).to.be('::ffff:127.0.0.1');
+          done();
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

The `remoteAddress` property is currently undefined when using `{ transports: [ 'websocket' ] }` and `uws` (which is the default since Socket.IO 2.x)

### New behaviour


### Other information (e.g. related issues)

Fixes https://github.com/socketio/socket.io/issues/2982

