### PR TITLE
Changing `generateId` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ to a single process.
     - Overwrite this method to generate your custom socket id.
     - **Parameters**
       - `http.IncomingMessage`: a node request object
-  - **Returns** A socket id for connected client.
+      - `Function`: a callback method which contains the generated id value
 
 <hr><br>
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -281,8 +281,8 @@ function sendErrorMessage (req, res, code) {
  * @api public
  */
 
-Server.prototype.generateId = function (req) {
-  return base64id.generateId();
+Server.prototype.generateId = function (req, callback) {
+  callback(base64id.generateId());
 };
 
 /**
@@ -294,52 +294,52 @@ Server.prototype.generateId = function (req) {
  */
 
 Server.prototype.handshake = function (transportName, req) {
-  var id = this.generateId(req);
-
-  debug('handshaking client "%s"', id);
-
-  try {
-    var transport = new transports[transportName](req);
-    if ('polling' === transportName) {
-      transport.maxHttpBufferSize = this.maxHttpBufferSize;
-      transport.httpCompression = this.httpCompression;
-    } else if ('websocket' === transportName) {
-      transport.perMessageDeflate = this.perMessageDeflate;
-    }
-
-    if (req._query && req._query.b64) {
-      transport.supportsBinary = false;
-    } else {
-      transport.supportsBinary = true;
-    }
-  } catch (e) {
-    sendErrorMessage(req, req.res, Server.errors.BAD_REQUEST);
-    return;
-  }
-  var socket = new Socket(id, this, transport, req);
   var self = this;
+  this.generateId(req, function (id) {
+    debug('handshaking client "%s"', id);
 
-  if (false !== this.cookie) {
-    transport.on('headers', function (headers) {
-      headers['Set-Cookie'] = cookieMod.serialize(self.cookie, id,
-        {
-          path: self.cookiePath,
-          httpOnly: self.cookiePath ? self.cookieHttpOnly : false
-        });
+    try {
+      var transport = new transports[transportName](req);
+      if ('polling' === transportName) {
+        transport.maxHttpBufferSize = self.maxHttpBufferSize;
+        transport.httpCompression = self.httpCompression;
+      } else if ('websocket' === transportName) {
+        transport.perMessageDeflate = self.perMessageDeflate;
+      }
+
+      if (req._query && req._query.b64) {
+        transport.supportsBinary = false;
+      } else {
+        transport.supportsBinary = true;
+      }
+    } catch (e) {
+      sendErrorMessage(req, req.res, Server.errors.BAD_REQUEST);
+      return;
+    }
+    var socket = new Socket(id, self, transport, req);
+
+    if (false !== self.cookie) {
+      transport.on('headers', function (headers) {
+        headers['Set-Cookie'] = cookieMod.serialize(self.cookie, id,
+          {
+            path: self.cookiePath,
+            httpOnly: self.cookiePath ? self.cookieHttpOnly : false
+          });
+      });
+    }
+
+    transport.onRequest(req);
+
+    self.clients[id] = socket;
+    self.clientsCount++;
+
+    socket.once('close', function () {
+      delete self.clients[id];
+      self.clientsCount--;
     });
-  }
 
-  transport.onRequest(req);
-
-  this.clients[id] = socket;
-  this.clientsCount++;
-
-  socket.once('close', function () {
-    delete self.clients[id];
-    self.clientsCount--;
+    self.emit('connection', socket);  
   });
-
-  this.emit('connection', socket);
 };
 
 /**

--- a/lib/server.js
+++ b/lib/server.js
@@ -338,7 +338,7 @@ Server.prototype.handshake = function (transportName, req) {
       self.clientsCount--;
     });
 
-    self.emit('connection', socket);  
+    self.emit('connection', socket);
   });
 };
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
If overwritten and assigned `generateId` function needs some extra operation like Redis query, `id` value passed as undefined because Javascript runs asynchronously.


### New behaviour
Adding a callback to `generateId` method provides the program flow to continue after a new generated id is provided.

### Other information (e.g. related issues)
Also README file has been changed according to the updates above.

