### PR TITLE
Added some checks to prevent usage of undefined properties

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -266,11 +266,13 @@ function sendErrorMessage (req, res, code) {
   } else {
     headers['Access-Control-Allow-Origin'] = '*';
   }
-  res.writeHead(400, headers);
-  res.end(JSON.stringify({
-    code: code,
-    message: Server.errorMessages[code]
-  }));
+  if (res !== undefined) {
+    res.writeHead(400, headers);
+    res.end(JSON.stringify({
+      code: code,
+      message: Server.errorMessages[code]
+    }));
+  }
 }
 
 /**
@@ -383,7 +385,7 @@ Server.prototype.handleUpgrade = function (req, socket, upgradeHead) {
 Server.prototype.onWebSocket = function (req, socket) {
   socket.on('error', onUpgradeError);
 
-  if (!transports[req._query.transport].prototype.handlesUpgrades) {
+  if (transports[req._query.transport] !== undefined && !transports[req._query.transport].prototype.handlesUpgrades) {
     debug('transport doesnt handle upgraded requests');
     socket.close();
     return;


### PR DESCRIPTION
When testing our application with the OWASP ZAP tool we encountered exceptions on two different places which were caused by trying to access undefined properties


### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour


### New behaviour


### Other information (e.g. related issues)


