### PR TITLE
[chore] Bump ws to version 3.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "base64id": "1.0.0",
     "debug": "~2.6.9",
     "engine.io-parser": "~2.1.0",
-    "ws": "~2.3.1",
+    "ws": "~3.3.1",
     "cookie": "0.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes a [DoS vulnerability](https://github.com/websockets/ws/releases/tag/3.3.1).