### PR TITLE
[chore] Bump ws to version 1.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "base64id": "1.0.0",
     "debug": "2.3.3",
     "engine.io-parser": "1.3.2",
-    "ws": "1.1.4",
+    "ws": "1.1.5",
     "cookie": "0.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes a [DoS vulnerability](https://nodesecurity.io/advisories/550).