### PR TITLE
[chore] Bump accepts to version 1.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "accepts": "1.3.4",
+    "accepts": "~1.3.4",
     "base64id": "1.0.0",
     "debug": "~2.6.9",
     "engine.io-parser": "~2.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "accepts": "1.3.3",
+    "accepts": "1.3.4",
     "base64id": "1.0.0",
     "debug": "~2.6.9",
     "engine.io-parser": "~2.1.0",


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behaviour

accepts locked to 1.3.3 in package.json

### New behaviour

accepts locked to 1.3.4 in package.json

### Other information (e.g. related issues)

I stumbled upon this whilst trying to reduce the number of dependencies that require multiple different versions of the same dependency within the tree
