### PR TITLE
[refactor] Use Buffer.concat([]) to construct an empty buffer

### DIFF
--- a/lib/transports/polling.js
+++ b/lib/transports/polling.js
@@ -136,7 +136,7 @@ Polling.prototype.onDataRequest = function (req, res) {
   this.dataReq = req;
   this.dataRes = res;
 
-  var chunks = isBinary ? new Buffer(0) : ''; // eslint-disable-line node/no-deprecated-api
+  var chunks = isBinary ? Buffer.concat([]) : '';
   var self = this;
 
   function cleanup () {
@@ -162,7 +162,7 @@ Polling.prototype.onDataRequest = function (req, res) {
     }
 
     if (contentLength > self.maxHttpBufferSize) {
-      chunks = isBinary ? new Buffer(0) : ''; // eslint-disable-line node/no-deprecated-api
+      chunks = isBinary ? Buffer.concat([]) : '';
       req.connection.destroy();
     }
   }


### PR DESCRIPTION
As suggested there: https://github.com/socketio/engine.io/pull/530#discussion_r169813592


