### PR TITLE
Remove unnecessary assertion in test case.

### DIFF
--- a/test/engine.io.js
+++ b/test/engine.io.js
@@ -20,7 +20,6 @@ describe('engine', function () {
   });
 
   it('should be the same version as client', function () {
-    expect(eio.protocol).to.be.a('number');
     var version = require('../package').version;
     expect(version).to.be(require('engine.io-client/package').version);
   });


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behaviour
`should be the same version as client` is currently testing whether eio is exposing protocol number.
But `should expose protocol number` already tested.

### New behaviour
Remove assertion about protocol number in `should be the same version as client`.

### Other information (e.g. related issues)
All test passed.
