### PR TITLE
[fix] Processing error code on abort connection

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -502,7 +502,7 @@ Server.prototype.attach = function (server, options) {
 
 function abortConnection (socket, code) {
   if (socket.writable) {
-    var message = Server.errorMessages.hasOwnProperty(code) ? Server.errorMessages[code] : (code || '');
+    var message = Server.errorMessages.hasOwnProperty(code) ? Server.errorMessages[code] : String(code || '');
     var length = Buffer.byteLength(message);
     socket.write(
       'HTTP/1.1 400 Bad Request\r\n' +


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
When you use `allowRequest` and pass error as number (like internal Server.errorMessages but in other range) system throw `TypeError` exception.

### New behaviour
System will cat to string in any case.

### Other information (e.g. related issues)


