### PR TITLE
[fix] Replace deprecated Buffer usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ var server = engine.listen(80);
 
 server.on('connection', function(socket){
   socket.send('utf 8 string');
-  socket.send(new Buffer([0, 1, 2, 3, 4, 5])); // binary data
+  socket.send(Buffer.from([0, 1, 2, 3, 4, 5])); // binary data
 });
 ```
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -359,8 +359,7 @@ Server.prototype.handleUpgrade = function (req, socket, upgradeHead) {
       return;
     }
 
-    var head = new Buffer(upgradeHead.length); // eslint-disable-line node/no-deprecated-api
-    upgradeHead.copy(head);
+    var head = Buffer.from(upgradeHead); // eslint-disable-line node/no-deprecated-api
     upgradeHead = null;
 
     // delegate to ws


### PR DESCRIPTION
The `Buffer` constructor has been deprecated in favor of safer alternatives.
See https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/

### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behaviour
The `Buffer` constructor is used.

### New behaviour
`Buffer.from` is used instead.

### Other information (e.g. related issues)
The `README` has also been adjusted to not use the constructor in the example.

