### PR TITLE
Send additional cookies

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -282,6 +282,17 @@ Server.prototype.generateId = function (req) {
 };
 
 /**
+ * Get additional cookies
+ * Overwrite this method to have additional serialized cookies sent in the handshake
+ *
+ * @param {Object} req object
+ * @returns {Array}
+ */
+Server.prototype.getAdditionalCookies = function(req) {
+  return [];
+};
+
+/**
  * Handshakes a new client.
  *
  * @param {String} transport name
@@ -317,11 +328,13 @@ Server.prototype.handshake = function (transportName, req) {
 
   if (false !== this.cookie) {
     transport.on('headers', function (headers) {
-      headers['Set-Cookie'] = cookieMod.serialize(self.cookie, id,
-        {
-          path: self.cookiePath,
-          httpOnly: self.cookiePath ? self.cookieHttpOnly : false
-        });
+      var cookies = self.getAdditionalCookies(req) || [];
+      cookies.push(cookieMod.serialize(self.cookie, id, {
+        path: self.cookiePath,
+        httpOnly: self.cookiePath ? self.cookieHttpOnly : false
+      }));
+
+      headers['Set-Cookie'] = cookies;
     });
   }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -288,7 +288,7 @@ Server.prototype.generateId = function (req) {
  * @param {Object} req object
  * @returns {Array}
  */
-Server.prototype.getAdditionalCookies = function(req) {
+Server.prototype.getAdditionalCookies = function (req) {
   return [];
 };
 

--- a/test/server.js
+++ b/test/server.js
@@ -124,7 +124,7 @@ describe('server', function () {
     });
 
     it('should send additional cookies', function (done) {
-      let engine = listen(function (port) {
+      var engine = listen(function (port) {
         engine.getAdditionalCookies = function (req) {
           return ['additional=1234'];
         };

--- a/test/server.js
+++ b/test/server.js
@@ -123,6 +123,27 @@ describe('server', function () {
       });
     });
 
+    it('should send additional cookies', function (done) {
+      let engine = listen(function (port) {
+        engine.getAdditionalCookies = function (req) {
+          return ['additional=1234'];
+        };
+
+        request.get('http://localhost:%d/engine.io/default/'.s(port))
+          .query({ transport: 'polling', b64: 1 })
+          .end(function (err, res) {
+            expect(err).to.be(null);
+            // hack-obtain sid
+            var sid = res.text.match(/"sid":"([^"]+)"/)[1];
+            console.log(res.headers['set-cookie']);
+            expect(res.headers['set-cookie'].length).to.be(2);
+            expect(res.headers['set-cookie'][0]).to.be('additional=1234');
+            expect(res.headers['set-cookie'][1]).to.be('io=' + sid + '; Path=/; HttpOnly');
+            done();
+          });
+      });
+    });
+
     it('should send the io cookie custom name', function (done) {
       listen({ cookie: 'woot' }, function (port) {
         request.get('http://localhost:%d/engine.io/default/'.s(port))

--- a/test/server.js
+++ b/test/server.js
@@ -135,7 +135,6 @@ describe('server', function () {
             expect(err).to.be(null);
             // hack-obtain sid
             var sid = res.text.match(/"sid":"([^"]+)"/)[1];
-            console.log(res.headers['set-cookie']);
             expect(res.headers['set-cookie'].length).to.be(2);
             expect(res.headers['set-cookie'][0]).to.be('additional=1234');
             expect(res.headers['set-cookie'][1]).to.be('io=' + sid + '; Path=/; HttpOnly');


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
During the handshake, only the `io` cookie can be sent

### New behaviour
This PR allows the override of a function (`getAdditionalCookies`) to send any other cookies required


### Other information (e.g. related issues)
See issue #557 

Any and all feedback is greatly appreciated.
Keep up the good work!

