### PR TITLE
Read sid from header if not provided in query

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -152,7 +152,7 @@ Server.prototype.verify = function (req, upgrade, fn) {
   }
 
   // sid check
-  var sid = req._query.sid;
+  var sid = req._query.sid || req.headers.sid;
   if (sid) {
     if (!this.clients.hasOwnProperty(sid)) {
       return fn(Server.errors.UNKNOWN_SID, false);
@@ -225,9 +225,10 @@ Server.prototype.handleRequest = function (req, res) {
       return;
     }
 
-    if (req._query.sid) {
+    var sid = req._query.sid || req.headers.sid;
+    if (sid) {
       debug('setting new request for existing client');
-      self.clients[req._query.sid].transport.onRequest(req);
+      self.clients[sid].transport.onRequest(req);
     } else {
       self.handshake(req._query.transport, req);
     }
@@ -381,7 +382,7 @@ Server.prototype.onWebSocket = function (req, socket) {
   }
 
   // get client id
-  var id = req._query.sid;
+  var id = req._query.sid || req.headers.sid;
 
   // keep a reference to the ws.Socket
   req.websocket = socket;


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behaviour
For now, the sid is sent in the GET request parameters.
OWASP Zed Attack Proxy says there is a security issue
See https://github.com/socketio/socket.io/issues/3416

### New behaviour
If the sid is not provided in the GET request parameters, we try to find it in the headers

### Other information (e.g. related issues)
I will also propose a pull request in the socket.io repository so that the client sends the sid in the header.

