### PR TITLE
migrate to uWebSockets.js

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -102,19 +102,25 @@ Server.prototype.init = function () {
   if (!~this.transports.indexOf('websocket')) return;
 
   if (this.ws) this.ws.close();
-
   var wsModule;
   switch (this.wsEngine) {
-    case 'uws': wsModule = require('uws'); break;
-    case 'ws': wsModule = require('ws'); break;
+    case 'uws': {
+      wsModule = require('uWebSockets.js');
+      this.ws = new wsModule.App();
+      break;
+    }
+    case 'ws': {
+      wsModule = require('ws');
+      this.ws = new wsModule.Server({
+        noServer: true,
+        clientTracking: false,
+        perMessageDeflate: this.perMessageDeflate,
+        maxPayload: this.maxHttpBufferSize
+      });
+      break;
+    }
     default: throw new Error('unknown wsEngine');
   }
-  this.ws = new wsModule.Server({
-    noServer: true,
-    clientTracking: false,
-    perMessageDeflate: this.perMessageDeflate,
-    maxPayload: this.maxHttpBufferSize
-  });
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -27,10 +27,11 @@
   "dependencies": {
     "accepts": "~1.3.4",
     "base64id": "1.0.0",
+    "cookie": "0.3.1",
     "debug": "~3.1.0",
     "engine.io-parser": "~2.1.0",
-    "ws": "~6.1.0",
-    "cookie": "0.3.1"
+    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v15.10.0",
+    "ws": "~6.1.0"
   },
   "devDependencies": {
     "babel-eslint": "^8.0.2",
@@ -45,8 +46,7 @@
     "expect.js": "^0.3.1",
     "mocha": "^4.0.1",
     "s": "0.1.1",
-    "superagent": "^3.8.1",
-    "uws": "~9.14.0"
+    "superagent": "^3.8.1"
   },
   "scripts": {
     "lint": "eslint lib/ test/ *.js",

--- a/test/server.js
+++ b/test/server.js
@@ -2654,7 +2654,7 @@ describe('server', function () {
   describe('wsEngine option', function () {
     it('should allow loading of other websocket server implementation like uws', function (done) {
       var engine = listen({ allowUpgrades: false, wsEngine: 'uws' }, function (port) {
-        expect(engine.ws instanceof require('uws').Server).to.be.ok();
+        expect(engine.ws instanceof require('uWebSockets.js').App).to.be.ok();
         var socket = new eioc.Socket('ws://localhost:%d'.s(port));
         engine.on('connection', function (conn) {
           conn.send('a');


### PR DESCRIPTION
This PR is not necessarily meant to merged but rather to continue the conversation with code rather than speculating and ghosting on issues. I believe a lot of us are waiting on some type of answer and personally, switching to [`ws` ](https://www.npmjs.com/package/ws)as the background WebSocket engine is not an acceptable performance loss.

*Failing test was failing before changes were made.

### The kind of change this PR does introduce
 - [x] a bug fix
 - [ ] a new feature
 - [ ] an update to the documentation
 - [x] a code change that improves performance
 - [ ] other


### Current behaviour
`uws` is no longer maintained

### New behaviour
Migrate to `uWebSockets.js` - the latest iteration of `uws` for the Node ecosystem.

### Other information (e.g. related issues)
https://github.com/socketio/engine.io/issues/578
https://github.com/socketio/engine.io/issues/575
https://github.com/socketio/engine.io/issues/567
https://github.com/socketio/engine.io/issues/560
https://github.com/socketio/socket.io/issues/3342

[The internet](https://www.reddit.com/r/node/comments/91kgte/uws_has_been_deprecated/)