### PR TITLE
[fix] Deprecated Buffer usage in dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "accepts": "~1.3.4",
-    "base64id": "1.0.0",
+    "base64id": "2.0.0",
     "debug": "~3.1.0",
     "engine.io-parser": "~2.1.0",
     "ws": "~6.1.0",


### PR DESCRIPTION
The `Buffer` constructor has been deprecated in favor of safer alternatives.
See https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/

This was fixed in base64id@2.0.0

Relates to #565


### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour


### New behaviour


### Other information (e.g. related issues)


