### PR TITLE
Additional debug messaging

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -555,23 +555,33 @@ function checkInvalidHeaderChar(val) {
   val += '';
   if (val.length < 1)
     return false;
-  if (!validHdrChars[val.charCodeAt(0)])
+  if (!validHdrChars[val.charCodeAt(0)]) {
+    debug('invalid header, index 0, char "%s"', val.charCodeAt(0));
     return true;
+  }
   if (val.length < 2)
     return false;
-  if (!validHdrChars[val.charCodeAt(1)])
+  if (!validHdrChars[val.charCodeAt(1)]) {
+    debug('invalid header, index 1, char "%s"', val.charCodeAt(1));
     return true;
+  }
   if (val.length < 3)
     return false;
-  if (!validHdrChars[val.charCodeAt(2)])
+  if (!validHdrChars[val.charCodeAt(2)]) {
+    debug('invalid header, index 2, char "%s"', val.charCodeAt(2));
     return true;
+  }
   if (val.length < 4)
     return false;
-  if (!validHdrChars[val.charCodeAt(3)])
+  if (!validHdrChars[val.charCodeAt(3)]) {
+    debug('invalid header, index 3, char "%s"', val.charCodeAt(3));
     return true;
+  }
   for (var i = 4; i < val.length; ++i) {
-    if (!validHdrChars[val.charCodeAt(i)])
+    if (!validHdrChars[val.charCodeAt(i)]) {
+      debug('invalid header, index "%i", char "%s"', i, val.charCodeAt(i));
       return true;
+    }
   }
   return false;
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -148,6 +148,7 @@ Server.prototype.verify = function (req, upgrade, fn) {
   var isOriginInvalid = checkInvalidHeaderChar(req.headers.origin);
   if (isOriginInvalid) {
     req.headers.origin = null;
+    debug('origin header invalid');
     return fn(Server.errors.BAD_REQUEST, false);
   }
 
@@ -155,6 +156,7 @@ Server.prototype.verify = function (req, upgrade, fn) {
   var sid = req._query.sid;
   if (sid) {
     if (!this.clients.hasOwnProperty(sid)) {
+      debug('unknown sid "%s"', sid);
       return fn(Server.errors.UNKNOWN_SID, false);
     }
     if (!upgrade && this.clients[sid].transport.name !== transport) {
@@ -309,6 +311,7 @@ Server.prototype.handshake = function (transportName, req) {
       transport.supportsBinary = true;
     }
   } catch (e) {
+    debug('error handshaking to transport "%s"', transportName);
     sendErrorMessage(req, req.res, Server.errors.BAD_REQUEST);
     return;
   }


### PR DESCRIPTION
### The kind of change this PR does introduce

* [] a bug fix
* [ ] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behaviour

Troubleshooting by turning debug messages on for engine.io does not reveal reason for error for:

* Unknown session id
* Invalid origin header
* Invalid transport parameter

### New behaviour

Turning debug messages on for engine.io provides debug logging to help indicate
reason for various 400 bad request messages.

### Other information (e.g. related issues)

These additional messages would have helped more quickly diagnose the
reason for error messages we were seeing on a socket.io server interfacing with
many different socket.io client libraries.