### PR TITLE
Processing socket error on upgrade

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -417,6 +417,9 @@ class Server extends EventEmitter {
 
     if (~self.opts.transports.indexOf("websocket")) {
       server.on("upgrade", function(req, socket, head) {
+        socket.on("error", function() {
+          debug("socket error on upgrade");
+        });
         if (check(req)) {
           self.handleUpgrade(req, socket, head);
         } else if (false !== options.destroyUpgrade) {


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
nodejs 12.16.1
socket.io 2.3.0
engine.io 3.4.0
```
events.js:288
      throw er; // Unhandled 'error' event
      ^

Error: write EPIPE
    at afterWriteDispatched (internal/stream_base_commons.js:154:25)
    at writeGeneric (internal/stream_base_commons.js:145:3)
    at Socket._writeGeneric (net.js:780:11)
    at Socket._write (net.js:792:8)
    at doWrite (_stream_writable.js:441:12)
    at writeOrBuffer (_stream_writable.js:425:5)
    at Socket.Writable.write (_stream_writable.js:316:11)
    at abortConnection (/PATHTO/node_modules/engine.io/lib/server.js:506:12)
    at /PATHTO/node_modules/engine.io/lib/server.js:353:7
    at Server.verify (/PATHTO/node_modules/engine.io/lib/server.js:158:14)
    at Server.handleUpgrade (/PATHTO/node_modules/engine.io/lib/server.js:351:8)
    at Server.<anonymous> (/PATHTO/node_modules/engine.io/lib/server.js:478:14)
    at Server.emit (events.js:311:20)
    at Server.EventEmitter.emit (domain.js:482:12)
    at onParserExecuteCommon (_http_server.js:642:14)
    at onParserExecute (_http_server.js:583:3)
Emitted 'error' event on Socket instance at:
    at errorOrDestroy (internal/streams/destroy.js:108:12)
    at onwriteError (_stream_writable.js:456:5)
    at onwrite (_stream_writable.js:483:5)
    at internal/streams/destroy.js:50:7
    at Socket._destroy (net.js:673:5)
    at Socket.destroy (internal/streams/destroy.js:38:8)
    at afterWriteDispatched (internal/stream_base_commons.js:154:17)
    at writeGeneric (internal/stream_base_commons.js:145:3)
    [... lines matching original stack trace ...]
    at Server.verify (/PATHTO/node_modules/engine.io/lib/server.js:158:14) {
  errno: 'EPIPE',
  code: 'EPIPE',
  syscall: 'write'
```

### New behaviour


### Other information (e.g. related issues)


