### PR TITLE
fix: ignore error when forcefully closing the socket

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -503,6 +503,9 @@ function sendErrorMessage(req, res, code) {
  */
 
 function abortConnection(socket, code) {
+  socket.on("error", () => {
+    debug("ignoring error from closed connection");
+  });
   if (socket.writable) {
     const message = Server.errorMessages.hasOwnProperty(code)
       ? Server.errorMessages[code]

--- a/test/server.js
+++ b/test/server.js
@@ -804,17 +804,22 @@ describe("server", function() {
 
     it("should abort connection when upgrade fails", function(done) {
       listen({ allowUpgrades: true }, function(port) {
-        const req = http.request("http://localhost:%d/engine.io/".s(port), {
-          headers: {
-            connection: "Upgrade",
-            upgrade: "websocket"
+        const req = http.request(
+          {
+            port,
+            path: "/engine.io/",
+            headers: {
+              connection: "Upgrade",
+              upgrade: "websocket"
+            }
+          },
+          res => {
+            expect(res.statusCode).to.eql(400);
+            res.resume();
+            res.on("end", done);
           }
-        });
-        req.once("response", res => {
-          expect(res.statusCode).to.eql(400);
-          res.resume();
-          res.on("end", done);
-        });
+        );
+
         req.end();
       });
     });

--- a/test/server.js
+++ b/test/server.js
@@ -802,8 +802,8 @@ describe("server", function() {
       });
     });
 
-    it("should abort connection when upgrade fails", (done) => {
-      listen({ allowUpgrades: true }, (port) => {
+    it("should abort connection when upgrade fails", done => {
+      listen({ allowUpgrades: true }, port => {
         const req = http.request(
           {
             port,

--- a/test/server.js
+++ b/test/server.js
@@ -802,6 +802,23 @@ describe("server", function() {
       });
     });
 
+    it("should abort connection when upgrade fails", function(done) {
+      listen({ allowUpgrades: true }, function(port) {
+        const req = http.request("http://localhost:%d/engine.io/".s(port), {
+          headers: {
+            connection: "Upgrade",
+            upgrade: "websocket"
+          }
+        });
+        req.once("response", res => {
+          expect(res.statusCode).to.eql(400);
+          res.resume();
+          res.on("end", done);
+        });
+        req.end();
+      });
+    });
+
     it(
       "should trigger if a poll request is ongoing and the underlying " +
         "socket closes, as in a browser tab close",

--- a/test/server.js
+++ b/test/server.js
@@ -802,8 +802,8 @@ describe("server", function() {
       });
     });
 
-    it("should abort connection when upgrade fails", function(done) {
-      listen({ allowUpgrades: true }, function(port) {
+    it("should abort connection when upgrade fails", (done) => {
+      listen({ allowUpgrades: true }, (port) => {
         const req = http.request(
           {
             port,
@@ -819,7 +819,6 @@ describe("server", function() {
             res.on("end", done);
           }
         );
-
         req.end();
       });
     });


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Other information (e.g. related issues)

- https://github.com/socketio/engine.io/pull/598
- https://github.com/socketio/engine.io/issues/596

