### PR TITLE
Add cookie options for sameSite and secure

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -47,6 +47,8 @@ function Server (opts) {
   this.cookie = false !== opts.cookie ? (opts.cookie || 'io') : false;
   this.cookiePath = false !== opts.cookiePath ? (opts.cookiePath || '/') : false;
   this.cookieHttpOnly = false !== opts.cookieHttpOnly;
+  this.sameSite = opts.sameSite || true;
+  this.secure = !!(opts.secure || opts.sameSite);
   this.perMessageDeflate = false !== opts.perMessageDeflate ? (opts.perMessageDeflate || true) : false;
   this.httpCompression = false !== opts.httpCompression ? (opts.httpCompression || {}) : false;
   this.initialPacket = opts.initialPacket;
@@ -320,7 +322,8 @@ Server.prototype.handshake = function (transportName, req) {
         {
           path: self.cookiePath,
           httpOnly: self.cookiePath ? self.cookieHttpOnly : false,
-          sameSite: true
+          sameSite: self.sameSite,
+          secure: self.secure
         });
     });
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -974,9 +974,9 @@
       "dev": true
     },
     "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
     },
     "cookiejar": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "accepts": "~1.3.4",
     "base64id": "2.0.0",
-    "cookie": "0.3.1",
+    "cookie": "~0.4.0",
     "debug": "~4.1.0",
     "engine.io-parser": "~2.2.0",
     "ws": "^7.1.2"


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

Fixes #603 

### Current behaviour
`SameSite` is set to `Strict`

### New behaviour
`SameSite` can be set to `None`

### Other information (e.g. related issues)
Updated `cookie` dependency to get `SameSite=None` support

It looks like there have been significant changes since the the 3.4 branch so I made these there since it looks like those changes will allow for better control for things like this already but I'm assuming will be a breaking change that will be released at some point in the future