### PR TITLE
package.json main entry missing extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "engine.io",
   "version": "4.0.1",
   "description": "The realtime engine behind Socket.IO. Provides the foundation of a bidirectional connection between client and server",
-  "main": "lib/engine.io",
+  "main": "lib/engine.io.js",
   "author": "Guillermo Rauch <guillermo@learnboost.com>",
   "homepage": "https://github.com/socketio/engine.io",
   "contributors": [


### PR DESCRIPTION
The `main` entry for the `package.json` file is for defining the entry point. The entry is currently missing the required `.js` extension, this PR brings it back.


### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
The `main` entry in the `package.json` file requires an extension that is currently lacking. This causes issues when tools try to automatically find the `main` file based off the `package.json` (you end up with a file not found exception)

### New behaviour
Added the `.js` extension to the entry for `main.js`

### Other information (e.g. related issues)
Resolves #607 

