### PR TITLE
fix: correctly pass the options when using the Server constructor

### DIFF
--- a/lib/engine.io.js
+++ b/lib/engine.io.js
@@ -26,7 +26,7 @@ exports = module.exports = function() {
   }
 
   // if first argument is not an http server, then just make a regular eio server
-  return new Server(arguments);
+  return new Server(...arguments);
 };
 
 /**

--- a/test/engine.io.js
+++ b/test/engine.io.js
@@ -25,6 +25,11 @@ describe("engine", () => {
       expect(engine).to.be.an(eio.Server);
       expect(engine.ws).to.be.ok();
     });
+
+    it("should pass options correctly to the Server", () => {
+      const engine = eio({ cors: true });
+      expect(engine.opts).to.have.property("cors", true);
+    });
   });
 
   describe("listen", () => {


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
When sending options to the Server constructor directly, they are not merged with the default ones.

### New behaviour
Sent options are now correctly merged.

### Other information (e.g. related issues)
Fixes #580 