### PR TITLE
feat: decrease the default value of maxHttpBufferSize

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -40,7 +40,7 @@ function Server (opts) {
   this.pingTimeout = opts.pingTimeout || 5000;
   this.pingInterval = opts.pingInterval || 25000;
   this.upgradeTimeout = opts.upgradeTimeout || 10000;
-  this.maxHttpBufferSize = opts.maxHttpBufferSize || 10E7;
+  this.maxHttpBufferSize = opts.maxHttpBufferSize || 1e6;
   this.transports = opts.transports || Object.keys(transports);
   this.allowUpgrades = false !== opts.allowUpgrades;
   this.allowRequest = opts.allowRequest;


### PR DESCRIPTION
Port of https://github.com/socketio/engine.io/commit/734f9d1268840722c41219e69eb58318e0b2ac6b to 3.5.x to fix CVE-2020-36048 


