### PR TITLE
fix: set default protocol version to 3 to allow backward compatibilit…

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -229,7 +229,7 @@ class Server extends EventEmitter {
    * @api private
    */
   async handshake(transportName, req) {
-    const protocol = req._query.EIO === "3" ? 3 : 4; // 4th revision by default
+    const protocol = req._query.EIO === "4" ? 4 : 3; // 3rd revision by default (this makes engine.io truly backward compatible)
     if (protocol === 3 && !this.opts.allowEIO3) {
       debug("unsupported protocol version");
       sendErrorMessage(

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -22,8 +22,8 @@ class Transport extends EventEmitter {
     super();
     this.readyState = "open";
     this.discarded = false;
-    this.protocol = req._query.EIO === "3" ? 3 : 4; // 4th revision by default
-    this.parser = this.protocol === 3 ? parser_v3 : parser_v4;
+    this.protocol = req._query.EIO === "4" ? 4 : 3; // 3rd revision by default (this makes engine.io truly backward compatible)
+    this.parser = this.protocol === 4 ? parser_v4 : parser_v3;
   }
 
   /**


### PR DESCRIPTION
…y of socket.io-client-swift

socket.io-client-swift libs version <=15.2.0, which uses protocol version 3, do not explicitly add the EIO query parameter at transport initialization. This omission leads the server to treat the client as a client that supports the protocol version 4, previously set as default, which is not correct for those versions of the client lib.

From socket.io-client-swift version v16.0.0 the EIO query parameter is explicitly passed to specify the protocol version supported, but since the allowEIO3 parameter aims to make the server compatible with previous versions which in most of the cases are already used in production and not easily upgradable, it makes more sense to default the EIO version to 3 if not explicitly set by the client since the newer client versions pass the EIO protocol version in query parameters.


### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
socket.io-client-swift libs version <=15.2.0 cannot connect due to parsing errors since they are treated as client that support EIO protocol 4 but they supporto EIO protocol 3.

### New behaviour
socket.io-client-swift libs version <=15.2.0 are correctly identified as EIO protocol 3 client and can connect correctly

### Other information (e.g. related issues)
MOTIVATION: this new version of engine.io is used by the new version of socket.io and have a flag that allow backward compatibility with older client versions that implement EIO protocol version 3, but this is not true in practice since the EIO protocol used is defaulted to 4 if not explicitly indicated in the connection request, as in the case of socket.io-client-swift libs version <=15.2.0. Since is very likely that an update to socket.io from v2 to v3 involves the connection from clients that implements both EIO protocol 3 and 4, it makes sense to maintain the backward compatibility for all the client libs.

