### PR TITLE
Implementing #576 connection_dropped event with reason and context

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,11 @@ The main server/manager. _Inherits from EventEmitter_.
 - `connection_dropped`
     - Fired when a new connection could not be established.
     - **Arguments**
-      - `context`: A context object depending on the reason
+      - `error`: an object with following properties:
+        - `req` (`http.IncomingMessage`): the request that was dropped
+        - `code` (`Number`): one of `Server`.`errors`
+        - `message` (`string`): one of `Server`.`errorMessages`
+        - `context` (`Object`): extra info from the check that dropped the connection
 
 ##### Properties
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ The main server/manager. _Inherits from EventEmitter_.
     - Fired when a new connection is established.
     - **Arguments**
       - `Socket`: a Socket object
+- `connection_dropped`
+    - Fired when a new connection could not be established.
+    - **Arguments**
+      - `context`: A context object depending on the reason
 
 ##### Properties
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -137,15 +137,21 @@ Server.prototype.verify = function (req, upgrade, fn) {
   var transport = req._query.transport;
   if (!~this.transports.indexOf(transport)) {
     debug('unknown transport "%s"', transport);
-    return fn(Server.errors.UNKNOWN_TRANSPORT, false);
+    return fn(Server.errors.UNKNOWN_TRANSPORT, {
+      transport: transport
+    });
   }
 
   // 'Origin' header check
   var isOriginInvalid = checkInvalidHeaderChar(req.headers.origin);
   if (isOriginInvalid) {
+    var origin = req.headers.origin;
     req.headers.origin = null;
     debug('origin header invalid');
-    return fn(Server.errors.BAD_REQUEST, false);
+    return fn(Server.errors.BAD_REQUEST, {
+      name: 'INVALID_ORIGIN',
+      origin: origin
+    });
   }
 
   // sid check
@@ -153,20 +159,41 @@ Server.prototype.verify = function (req, upgrade, fn) {
   if (sid) {
     if (!this.clients.hasOwnProperty(sid)) {
       debug('unknown sid "%s"', sid);
-      return fn(Server.errors.UNKNOWN_SID, false);
+      return fn(Server.errors.UNKNOWN_SID, {
+        sid: sid
+      });
     }
-    if (!upgrade && this.clients[sid].transport.name !== transport) {
+    var previousTransport = this.clients[sid].transport.name;
+    if (!upgrade && previousTransport !== transport) {
       debug('bad request: unexpected transport without upgrade');
-      return fn(Server.errors.BAD_REQUEST, false);
+      return fn(Server.errors.BAD_REQUEST, {
+        name: 'TRANSPORT_MISMATCH',
+        transport: transport,
+        previous: previousTransport
+      });
     }
   } else {
     // handshake is GET only
-    if ('GET' !== req.method) return fn(Server.errors.BAD_HANDSHAKE_METHOD, false);
-    if (!this.allowRequest) return fn(null, true);
-    return this.allowRequest(req, fn);
+    if ('GET' !== req.method) {
+      return fn(Server.errors.BAD_HANDSHAKE_METHOD, {
+        method: req.method
+      });
+    }
+
+    if (!this.allowRequest) return fn();
+
+    return this.allowRequest(req, function (code, success) {
+      if (!success) {
+        return fn(Server.errors.FORBIDDEN, {
+          code: code
+        });
+      }
+
+      fn();
+    });
   }
 
-  fn(null, true);
+  fn();
 };
 
 /**
@@ -217,9 +244,10 @@ Server.prototype.handleRequest = function (req, res) {
   req.res = res;
 
   var self = this;
-  this.verify(req, false, function (err, success) {
-    if (!success) {
-      sendErrorMessage(req, res, err);
+  this.verify(req, false, function (errorCode, errorContext) {
+    if (errorCode !== undefined) {
+      self.emit('connection_dropped', Server.errorMessages[errorCode], errorContext);
+      sendErrorMessage(req, res, errorCode, errorContext);
       return;
     }
 
@@ -240,29 +268,30 @@ Server.prototype.handleRequest = function (req, res) {
  * @api private
  */
 
-function sendErrorMessage (req, res, code) {
+function sendErrorMessage (req, res, errorCode, errorContext) {
   var headers = { 'Content-Type': 'application/json' };
 
-  var isForbidden = !Server.errorMessages.hasOwnProperty(code);
-  if (isForbidden) {
+  if (errorCode === Server.errors.FORBIDDEN) {
     res.writeHead(403, headers);
     res.end(JSON.stringify({
-      code: Server.errors.FORBIDDEN,
-      message: code || Server.errorMessages[Server.errors.FORBIDDEN]
+      code: errorCode,
+      message: errorContext.code || Server.errorMessages[errorCode]
     }));
     return;
   }
+
   if (req.headers.origin) {
     headers['Access-Control-Allow-Credentials'] = 'true';
     headers['Access-Control-Allow-Origin'] = req.headers.origin;
   } else {
     headers['Access-Control-Allow-Origin'] = '*';
   }
+
   if (res !== undefined) {
     res.writeHead(400, headers);
     res.end(JSON.stringify({
-      code: code,
-      message: Server.errorMessages[code]
+      code: errorCode,
+      message: Server.errorMessages[errorCode]
     }));
   }
 }
@@ -308,6 +337,10 @@ Server.prototype.handshake = function (transportName, req) {
     }
   } catch (e) {
     debug('error handshaking to transport "%s"', transportName);
+    this.emit('connection_dropped', Server.errorMessages[Server.errors.BAD_REQUEST], {
+      name: 'TRANSPORT_HANDSHAKE_ERROR',
+      error: e
+    });
     sendErrorMessage(req, req.res, Server.errors.BAD_REQUEST);
     return;
   }
@@ -348,9 +381,10 @@ Server.prototype.handleUpgrade = function (req, socket, upgradeHead) {
   this.prepare(req);
 
   var self = this;
-  this.verify(req, true, function (err, success) {
-    if (!success) {
-      abortConnection(socket, err);
+  this.verify(req, true, function (errorCode, errorContext) {
+    if (errorCode !== undefined) {
+      self.emit('connection_dropped', errorCode, errorContext);
+      abortConnection(socket, errorCode, errorContext);
       return;
     }
 
@@ -499,12 +533,12 @@ Server.prototype.attach = function (server, options) {
  * @api private
  */
 
-function abortConnection (socket, code) {
+function abortConnection (socket, code, context) {
   socket.on('error', () => {
     debug('ignoring error from closed connection');
   });
   if (socket.writable) {
-    var message = Server.errorMessages.hasOwnProperty(code) ? Server.errorMessages[code] : String(code || '');
+    var message = context.code || Server.errorMessages[code];
     var length = Buffer.byteLength(message);
     socket.write(
       'HTTP/1.1 400 Bad Request\r\n' +

--- a/lib/server.js
+++ b/lib/server.js
@@ -182,10 +182,10 @@ Server.prototype.verify = function (req, upgrade, fn) {
 
     if (!this.allowRequest) return fn();
 
-    return this.allowRequest(req, function (code, success) {
+    return this.allowRequest(req, function (message, success) {
       if (!success) {
         return fn(Server.errors.FORBIDDEN, {
-          code: code
+          message: message
         });
       }
 
@@ -246,7 +246,12 @@ Server.prototype.handleRequest = function (req, res) {
   var self = this;
   this.verify(req, false, function (errorCode, errorContext) {
     if (errorCode !== undefined) {
-      self.emit('connection_dropped', Server.errorMessages[errorCode], errorContext);
+      self.emit('connection_dropped', {
+        req: req,
+        code: errorCode,
+        message: Server.errorMessages[errorCode],
+        context: errorContext
+      });
       sendErrorMessage(req, res, errorCode, errorContext);
       return;
     }
@@ -269,13 +274,17 @@ Server.prototype.handleRequest = function (req, res) {
  */
 
 function sendErrorMessage (req, res, errorCode, errorContext) {
+  if (res === undefined) {
+    return;
+  }
+
   var headers = { 'Content-Type': 'application/json' };
 
   if (errorCode === Server.errors.FORBIDDEN) {
     res.writeHead(403, headers);
     res.end(JSON.stringify({
       code: errorCode,
-      message: errorContext.code || Server.errorMessages[errorCode]
+      message: errorContext.message || Server.errorMessages[errorCode]
     }));
     return;
   }
@@ -287,13 +296,11 @@ function sendErrorMessage (req, res, errorCode, errorContext) {
     headers['Access-Control-Allow-Origin'] = '*';
   }
 
-  if (res !== undefined) {
-    res.writeHead(400, headers);
-    res.end(JSON.stringify({
-      code: errorCode,
-      message: Server.errorMessages[errorCode]
-    }));
-  }
+  res.writeHead(400, headers);
+  res.end(JSON.stringify({
+    code: errorCode,
+    message: Server.errorMessages[errorCode]
+  }));
 }
 
 /**
@@ -337,9 +344,14 @@ Server.prototype.handshake = function (transportName, req) {
     }
   } catch (e) {
     debug('error handshaking to transport "%s"', transportName);
-    this.emit('connection_dropped', Server.errorMessages[Server.errors.BAD_REQUEST], {
-      name: 'TRANSPORT_HANDSHAKE_ERROR',
-      error: e
+    this.emit('connection_dropped', {
+      req: req,
+      code: Server.errors.BAD_REQUEST,
+      message: Server.errorMessages[Server.errors.BAD_REQUEST],
+      context: {
+        name: 'TRANSPORT_HANDSHAKE_ERROR',
+        error: e
+      }
     });
     sendErrorMessage(req, req.res, Server.errors.BAD_REQUEST);
     return;
@@ -383,7 +395,12 @@ Server.prototype.handleUpgrade = function (req, socket, upgradeHead) {
   var self = this;
   this.verify(req, true, function (errorCode, errorContext) {
     if (errorCode !== undefined) {
-      self.emit('connection_dropped', errorCode, errorContext);
+      self.emit('connection_dropped', {
+        req: req,
+        code: errorCode,
+        message: Server.errorMessages[errorCode],
+        context: errorContext
+      });
       abortConnection(socket, errorCode, errorContext);
       return;
     }
@@ -538,7 +555,7 @@ function abortConnection (socket, code, context) {
     debug('ignoring error from closed connection');
   });
   if (socket.writable) {
-    var message = context.code || Server.errorMessages[code];
+    var message = context.message || Server.errorMessages[code];
     var length = Buffer.byteLength(message);
     socket.write(
       'HTTP/1.1 400 Bad Request\r\n' +

--- a/test/server.js
+++ b/test/server.js
@@ -52,7 +52,7 @@ describe('server', function () {
             onDone();
           });
 
-        function onDone() {
+        function onDone () {
           --total || done();
         }
       });
@@ -82,7 +82,7 @@ describe('server', function () {
             onDone();
           });
 
-        function onDone() {
+        function onDone () {
           --total || done();
         }
       });
@@ -111,7 +111,7 @@ describe('server', function () {
             onDone();
           });
 
-        function onDone() {
+        function onDone () {
           --total || done();
         }
       });
@@ -140,7 +140,7 @@ describe('server', function () {
             onDone();
           });
 
-        function onDone() {
+        function onDone () {
           --total || done();
         }
       });
@@ -438,7 +438,7 @@ describe('server', function () {
             });
         });
 
-        function onDone() {
+        function onDone () {
           --total || done();
         }
       });
@@ -492,7 +492,7 @@ describe('server', function () {
             onDone();
           });
 
-        function onDone() {
+        function onDone () {
           --total || done();
         }
       });
@@ -504,7 +504,7 @@ describe('server', function () {
 
         // we can't send an invalid header through request.get
         // so add an invalid char here
-        engine.prepare = function(req) {
+        engine.prepare = function (req) {
           eio.Server.prototype.prepare.call(engine, req);
           req.headers.origin += '\n';
         };
@@ -529,7 +529,7 @@ describe('server', function () {
             onDone();
           });
 
-        function onDone() {
+        function onDone () {
           --total || done();
         }
       });
@@ -2724,7 +2724,7 @@ describe('server', function () {
             onDone();
           });
 
-        function onDone() {
+        function onDone () {
           --total || done();
         }
       });

--- a/test/server.js
+++ b/test/server.js
@@ -35,9 +35,11 @@ describe('server', function () {
       var engine = listen(function (port) {
         var total = 2;
 
-        engine.on('connection_dropped', function (reason, context) {
-          expect(reason).to.be('Transport unknown');
-          expect(context.transport).to.be('tobi');
+        engine.on('connection_dropped', function (err) {
+          expect(err.req).to.be.an(http.IncomingMessage);
+          expect(err.code).to.be(0);
+          expect(err.message).to.be('Transport unknown');
+          expect(err.context.transport).to.be('tobi');
           onDone();
         });
 
@@ -63,9 +65,11 @@ describe('server', function () {
       var engine = listen(function (port) {
         var total = 2;
 
-        engine.on('connection_dropped', function (reason, context) {
-          expect(reason).to.be('Transport unknown');
-          expect(context.transport).to.be('constructor');
+        engine.on('connection_dropped', function (err) {
+          expect(err.req).to.be.an(http.IncomingMessage);
+          expect(err.code).to.be(0);
+          expect(err.message).to.be('Transport unknown');
+          expect(err.context.transport).to.be('constructor');
           onDone();
         });
 
@@ -92,9 +96,11 @@ describe('server', function () {
       var engine = listen(function (port) {
         var total = 2;
 
-        engine.on('connection_dropped', function (reason, context) {
-          expect(reason).to.be('Session ID unknown');
-          expect(context.sid).to.be('test');
+        engine.on('connection_dropped', function (err) {
+          expect(err.req).to.be.an(http.IncomingMessage);
+          expect(err.code).to.be(1);
+          expect(err.message).to.be('Session ID unknown');
+          expect(err.context.sid).to.be('test');
           onDone();
         });
 
@@ -121,9 +127,11 @@ describe('server', function () {
       var engine = listen({ allowRequest: function (req, fn) { fn('Thou shall not pass', false); } }, function (port) {
         var total = 2;
 
-        engine.on('connection_dropped', function (reason, context) {
-          expect(reason).to.be('Forbidden');
-          expect(context.code).to.be('Thou shall not pass');
+        engine.on('connection_dropped', function (err) {
+          expect(err.req).to.be.an(http.IncomingMessage);
+          expect(err.code).to.be(4);
+          expect(err.message).to.be('Forbidden');
+          expect(err.context.message).to.be('Thou shall not pass');
           onDone();
         });
 
@@ -413,11 +421,13 @@ describe('server', function () {
           });
         });
 
-        engine.on('connection_dropped', function (reason, context) {
-          expect(reason).to.be('Bad request');
-          expect(context.name).to.be('TRANSPORT_MISMATCH');
-          expect(context.transport).to.be('websocket');
-          expect(context.previous).to.be('polling');
+        engine.on('connection_dropped', function (err) {
+          expect(err.req).to.be.an(http.IncomingMessage);
+          expect(err.code).to.be(3);
+          expect(err.message).to.be('Bad request');
+          expect(err.context.name).to.be('TRANSPORT_MISMATCH');
+          expect(err.context.transport).to.be('websocket');
+          expect(err.context.previous).to.be('polling');
           onDone();
         });
 
@@ -471,11 +481,13 @@ describe('server', function () {
       var engine = listen(function (port) {
         var total = 2;
 
-        engine.on('connection_dropped', function (reason, context) {
-          expect(reason).to.be('Bad request');
-          expect(context.name).to.be('TRANSPORT_HANDSHAKE_ERROR');
-          expect(context.error).to.be.an(Error);
-          expect(context.error.name).to.be('TypeError');
+        engine.on('connection_dropped', function (err) {
+          expect(err.req).to.be.an(http.IncomingMessage);
+          expect(err.code).to.be(3);
+          expect(err.message).to.be('Bad request');
+          expect(err.context.name).to.be('TRANSPORT_HANDSHAKE_ERROR');
+          expect(err.context.error).to.be.an(Error);
+          expect(err.context.error.name).to.be('TypeError');
           onDone();
         });
 
@@ -509,10 +521,12 @@ describe('server', function () {
           req.headers.origin += '\n';
         };
 
-        engine.on('connection_dropped', function (reason, context) {
-          expect(reason).to.be('Bad request');
-          expect(context.name).to.be('INVALID_ORIGIN');
-          expect(context.origin).to.be('http://engine.io/\n');
+        engine.on('connection_dropped', function (err) {
+          expect(err.req).to.be.an(http.IncomingMessage);
+          expect(err.code).to.be(3);
+          expect(err.message).to.be('Bad request');
+          expect(err.context.name).to.be('INVALID_ORIGIN');
+          expect(err.context.origin).to.be('http://engine.io/\n');
           onDone();
         });
 
@@ -2705,9 +2719,11 @@ describe('server', function () {
       var engine = listen({handlePreflightRequest: true}, function (port) {
         var total = 2;
 
-        engine.on('connection_dropped', function (reason, context) {
-          expect(reason).to.be('Bad handshake method');
-          expect(context.method).to.be('OPTIONS');
+        engine.on('connection_dropped', function (err) {
+          expect(err.req).to.be.an(http.IncomingMessage);
+          expect(err.code).to.be(2);
+          expect(err.message).to.be('Bad handshake method');
+          expect(err.context.method).to.be('OPTIONS');
           onDone();
         });
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
There's currently no way of knowing when a connection is dropped due to the internal validation of engine.io

### New behaviour
Added a new event `connection_dropped` with context for the various scenarios that cause a connection to be dropped

### Other information (e.g. related issues)
The PR is for the 3.4.x branch. Once we get this PR validated, we can add the same event to 3.5.x and 4.x branches

Engine.IO: https://github.com/socketio/engine.io/issues/576
Socket.IO: https://github.com/socketio/socket.io/issues/3819

### Review

1. Is there a hard need for [allowRequest to be able to dictate the message for the error page](https://github.com/socketio/engine.io/blob/4.1.1/test/server.js#L86) ?
2. Is the [res check really needed](https://github.com/socketio/engine.io/blob/4.1.1/lib/server.js#L492)?
    - It's set as `req.res` or passed directly in all callbacks?
    - If it can be undefined, why isn't it checked in the [FORBIDDEN branch](https://github.com/socketio/engine.io/blob/4.1.1/lib/server.js#L482)?
3. Updated the signature of [verify's callback](https://github.com/socketio/engine.io/blob/4.1.1/lib/server.js#L308) since it is [private](https://github.com/socketio/engine.io/blob/master/lib/server.js#L100)
    - Does anyone mind the `errorCode !== undefined` check in handleUpgrade and handleRequest ?
    - It's necessary since [UNKNOWN_TRANSPORT](https://github.com/socketio/engine.io/blob/4.1.1/lib/server.js#L452) is 0
4. Not particularly keen on BAD_REQUEST having a sub-name property, but adding new error codes would need to skip [UNSUPPORTED_PROTOCOL_VERSION](https://github.com/socketio/engine.io/blob/4.1.1/lib/server.js#L458) used in 4.x
5. Not particularly keen on the context property being "dynamic". We could update to use `new Error()`, but I've seen that's not particularly common.