### PR TITLE
websocket: fix write back-pressure

### DIFF
--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -63,33 +63,35 @@ class WebSocket extends Transport {
    * @api private
    */
   send(packets) {
-    for (let i = 0; i < packets.length; i++) {
-      const packet = packets[i];
-
-      // always creates a new object since ws modifies it
-      const opts = {};
-      if (packet.options) {
-        opts.compress = packet.options.compress;
-      }
-
-      this.parser.encodePacket(packet, this.supportsBinary, data => {
-        if (this.perMessageDeflate) {
-          const len =
-            "string" === typeof data ? Buffer.byteLength(data) : data.length;
-          if (len < this.perMessageDeflate.threshold) {
-            opts.compress = false;
-          }
-        }
-        debug('writing "%s"', data);
-        this.writable = false;
-
-        this.socket.send(data, opts, err => {
-          if (err) return this.onError("write error", err.stack);
-          this.writable = true;
-          this.emit("drain");
-        });
-      });
+    const packet = packets.shift();
+    if (typeof packet === "undefined") {
+      this.writable = true;
+      this.emit("drain");
+      return;
     }
+
+    // always creates a new object since ws modifies it
+    const opts = {};
+    if (packet.options) {
+      opts.compress = packet.options.compress;
+    }
+
+    this.parser.encodePacket(packet, this.supportsBinary, data => {
+      if (this.perMessageDeflate) {
+        const len =
+          "string" === typeof data ? Buffer.byteLength(data) : data.length;
+        if (len < this.perMessageDeflate.threshold) {
+          opts.compress = false;
+        }
+      }
+      debug('writing "%s"', data);
+      this.writable = false;
+
+      this.socket.send(data, opts, err => {
+        if (err) return this.onError("write error", err.stack);
+        this.send(packets);
+      });
+    });
   }
 
   /**

--- a/test/server.js
+++ b/test/server.js
@@ -1681,7 +1681,9 @@ describe("server", () => {
           conn.send("a");
           conn.send("b");
           conn.send("c");
-          conn.close();
+          setTimeout(() => {
+            conn.close();
+          }, 50);
         });
 
         socket.on("open", () => {


### PR DESCRIPTION
Websocket transport is eagerly writing to underlaying websocket
without respecting back-pressure.
When an event is emitted to multiple clients, socket.io adapter
sends the same packet object to all socket clients.
These packet objects are shared for all clients inside room.

Once the packet is sent to transport,
transport prepares buffer with transport headers and packet data
and the sharing among clients is lost.

This change significantly reduces memory usage when
many packets are emitted to many clients in a burst.

This change causes that buffered data is sent to clients
more evenly packet by packet.

This change slightly (up to 10%) improved write throughput in the tests where 
many packets are emitted to many clients in a burst. 

### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [x] a code change that improves performance
* [ ] other

### Current behaviour

Websocket transport does not respect back pressure from underlaying websocket

### New behaviour

Websocket transport respects back pressure from underlaying websocket

### Other information (e.g. related issues)


