### PR TITLE
docs: remove the extra bracket in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Engine.IO: the realtime engine
 
-[![Build Status](https://github.com/socketio/engine.io/workflows/CI/badge.svg?branch=master))](https://github.com/socketio/engine.io/actions)
+[![Build Status](https://github.com/socketio/engine.io/workflows/CI/badge.svg?branch=master)](https://github.com/socketio/engine.io/actions)
 [![NPM version](https://badge.fury.io/js/engine.io.svg)](http://badge.fury.io/js/engine.io)
 
 `Engine.IO` is the implementation of transport-based


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

As shown in the figure below, there is an extra bracket `)` in README

![image](https://user-images.githubusercontent.com/5035625/132459294-6e7e7efc-f575-4d2a-b88a-56b3b18f5d34.png)

### New behaviour

It looks neater without the extra parentheses. I have a little bit of OCD :joy:

![image](https://user-images.githubusercontent.com/5035625/132459534-248316bb-ec2f-4118-ba39-37e8af985ea8.png)

### Other information (e.g. related issues)


