### PR TITLE
Refresh ping timers

### DIFF
--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -137,7 +137,7 @@ export class Socket extends EventEmitter {
           return;
         }
         debug("got pong");
-        this.schedulePing();
+        this.pingIntervalTimer.refresh();
         this.emit("heartbeat");
         break;
 
@@ -170,7 +170,6 @@ export class Socket extends EventEmitter {
    * @api private
    */
   private schedulePing() {
-    clearTimeout(this.pingIntervalTimer);
     this.pingIntervalTimer = setTimeout(() => {
       debug(
         "writing ping packet - expecting pong within %sms",


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [x] a code change that improves performance
* [ ] other

### Current behaviour
Ping timers are repeatedly cleared and recreated

### New behaviour
Ping timers are refreshed instead which is more efficient

### Other information (e.g. related issues)
https://nodejs.org/docs/latest-v10.x/api/timers.html#timers_timeout_refresh

