### PR TITLE
import Node's setTimeout & clearTimeout to prevent ambiguity

### DIFF
--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -223,7 +223,7 @@ export class Socket extends EventEmitter {
     // this function will manage packet events (also message callbacks)
     this.setupSendCallback();
 
-    this.cleanupFn.push(function () {
+    this.cleanupFn.push(function() {
       transport.removeListener("error", onError);
       transport.removeListener("packet", onPacket);
       transport.removeListener("drain", flush);
@@ -343,7 +343,7 @@ export class Socket extends EventEmitter {
     }
 
     // silence further transport errors and prevent uncaught exceptions
-    this.transport.on("error", function () {
+    this.transport.on("error", function() {
       debug("error triggered by discarded transport");
     });
 

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -3,6 +3,7 @@ import debugModule from "debug";
 import { IncomingMessage } from "http";
 import { Transport } from "./transport";
 import { Server } from "./server";
+import { setTimeout, clearTimeout } from "timers";
 
 const debug = debugModule("engine:socket");
 
@@ -222,7 +223,7 @@ export class Socket extends EventEmitter {
     // this function will manage packet events (also message callbacks)
     this.setupSendCallback();
 
-    this.cleanupFn.push(function() {
+    this.cleanupFn.push(function () {
       transport.removeListener("error", onError);
       transport.removeListener("packet", onPacket);
       transport.removeListener("drain", flush);
@@ -342,7 +343,7 @@ export class Socket extends EventEmitter {
     }
 
     // silence further transport errors and prevent uncaught exceptions
-    this.transport.on("error", function() {
+    this.transport.on("error", function () {
       debug("error triggered by discarded transport");
     });
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
`setTimeout` in _lib/socket.ts_ can lead to error `this.pingIntervalTimer.refresh is not a function` because interpreter might see it as the javascript version, which doesn't have a `refresh()` function.

### New behaviour
Importing `setTimeout` and `clearTimout` from Node's  `timers` module explicitly doesn't result in the error anymore.

### Other information (e.g. related issues)
Solves the bug in this issue: https://github.com/socketio/engine.io/issues/631
The refresh() call was added here https://github.com/socketio/engine.io/pull/628

