### PR TITLE
Allow CorsOptionsDelegate as cors options

### DIFF
--- a/lib/server.ts
+++ b/lib/server.ts
@@ -9,7 +9,7 @@ import { serialize } from "cookie";
 import { Server as DEFAULT_WS_ENGINE } from "ws";
 import { IncomingMessage, Server as HttpServer } from "http";
 import { CookieSerializeOptions } from "cookie";
-import { CorsOptions } from "cors";
+import {CorsOptions, CorsOptionsDelegate} from "cors";
 
 const debug = debugModule("engine");
 
@@ -105,7 +105,7 @@ export interface ServerOptions {
   /**
    * the options that will be forwarded to the cors module
    */
-  cors?: CorsOptions;
+  cors?: CorsOptions|CorsOptionsDelegate;
   /**
    * whether to enable compatibility with Socket.IO v2 clients
    * @default false

--- a/lib/server.ts
+++ b/lib/server.ts
@@ -9,7 +9,7 @@ import { serialize } from "cookie";
 import { Server as DEFAULT_WS_ENGINE } from "ws";
 import { IncomingMessage, Server as HttpServer } from "http";
 import { CookieSerializeOptions } from "cookie";
-import {CorsOptions, CorsOptionsDelegate} from "cors";
+import { CorsOptions, CorsOptionsDelegate } from "cors";
 
 const debug = debugModule("engine");
 
@@ -105,7 +105,7 @@ export interface ServerOptions {
   /**
    * the options that will be forwarded to the cors module
    */
-  cors?: CorsOptions|CorsOptionsDelegate;
+  cors?: CorsOptions | CorsOptionsDelegate;
   /**
    * whether to enable compatibility with Socket.IO v2 clients
    * @default false


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
Following strict typescript rules you cannot set the `cors` options to be a function as [described here](https://www.npmjs.com/package/cors#configuring-cors-asynchronously)

### New behaviour
You can now set the `cors` options to be a delegated function to determine cors options dynamically.

### Other information (e.g. related issues)


