### PR TITLE
refactor: replace deprecated `String.prototype.substr()`

### DIFF
--- a/lib/parser-v3/index.ts
+++ b/lib/parser-v3/index.ts
@@ -137,7 +137,7 @@ export function decodePacket (data, binaryType, utf8decode) {
     type = data.charAt(0);
 
     if (type === 'b') {
-      return decodeBase64Packet(data.substr(1), binaryType);
+      return decodeBase64Packet(data.slice(1), binaryType);
     }
 
     if (utf8decode) {
@@ -152,7 +152,7 @@ export function decodePacket (data, binaryType, utf8decode) {
     }
 
     if (data.length > 1) {
-      return { type: packetslist[type], data: data.substring(1) };
+      return { type: packetslist[type], data: data.slice(1) };
     } else {
       return { type: packetslist[type] };
     }
@@ -191,7 +191,7 @@ function tryDecode(data) {
 
 export function decodeBase64Packet (msg, binaryType) {
   var type = packetslist[msg.charAt(0)];
-  var data = Buffer.from(msg.substr(1), 'base64');
+  var data = Buffer.from(msg.slice(1), 'base64');
   if (binaryType === 'arraybuffer') {
     var abv = new Uint8Array(data.length);
     for (var i = 0; i < abv.length; i++){
@@ -305,7 +305,7 @@ export function decodePayload (data, binaryType, callback) {
       return callback(err, 0, 1);
     }
 
-    msg = data.substr(i + 1, n);
+    msg = data.slice(i + 1, i + 1 + n);
 
     if (length != msg.length) {
       // parser error - ignoring payload

--- a/lib/server.ts
+++ b/lib/server.ts
@@ -555,7 +555,7 @@ export class Server extends BaseServer {
         return;
       }
 
-      const head = Buffer.from(upgradeHead); // eslint-disable-line node/no-deprecated-api
+      const head = Buffer.from(upgradeHead);
       upgradeHead = null;
 
       // delegate to ws
@@ -643,7 +643,7 @@ export class Server extends BaseServer {
     path += "/";
 
     function check(req) {
-      return path === req.url.substr(0, path.length);
+      return path === req.url.slice(0, path.length);
     }
 
     // cache and clean up listeners

--- a/test/server.js
+++ b/test/server.js
@@ -181,7 +181,7 @@ describe("server", () => {
           .get(`http://localhost:${port}/engine.io/`)
           .query({ transport: "polling", EIO: 4 })
           .end((err, res) => {
-            const sid = JSON.parse(res.text.substring(1)).sid;
+            const sid = JSON.parse(res.text.slice(1)).sid;
 
             request
               .get(`http://localhost:${port}/engine.io/`)
@@ -3357,7 +3357,7 @@ describe("server", () => {
             expect(res.headers["set-cookie"].length).to.be(2);
             expect(res.headers["set-cookie"][1]).to.be("mycookie=456");
 
-            const sid = JSON.parse(res.text.substring(5)).sid;
+            const sid = JSON.parse(res.text.slice(5)).sid;
 
             request
               .post(`http://localhost:${port}/engine.io/`)
@@ -3394,7 +3394,7 @@ describe("server", () => {
             expect(res.headers["set-cookie"].length).to.be(2);
             expect(res.headers["set-cookie"][1]).to.be("mycookie=456");
 
-            const sid = JSON.parse(res.text.substring(5)).sid;
+            const sid = JSON.parse(res.text.slice(5)).sid;
 
             request
               .post(`http://localhost:${port}/engine.io/`)


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behaviour
Deprecated [`String.prototype.substr()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is used.

### New behaviour
[`String.prototype.slice()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) is used instead.

### Other information (e.g. related issues)

Apart from changing all `String.prototype.substr()` to `String.prototype.slice()`, also changed `String.prototype.substring()` to `String.prototype.slice()` for consistency so there are no two different functions that are doing the essentially the same thing.

In addition, removed `// eslint-disable-line node/no-deprecated-api` as it is redundant following PR #565.