### PR TITLE
Adding trailing slash option

### DIFF
--- a/lib/server.ts
+++ b/lib/server.ts
@@ -31,6 +31,12 @@ export interface AttachOptions {
    * @default 1000
    */
   destroyUpgradeTimeout?: number;
+
+  /**
+   * Should we add a trailing slash to the path?
+   * @default true
+   */
+  trailingSlash?: boolean;
 }
 
 export interface ServerOptions {
@@ -638,9 +644,10 @@ export class Server extends BaseServer {
     let path = (options.path || "/engine.io").replace(/\/$/, "");
 
     const destroyUpgradeTimeout = options.destroyUpgradeTimeout || 1000;
+    const trailingSlash = options.trailingSlash || true;
 
     // normalize path
-    path += "/";
+    path += trailingSlash ? "/" : "";
 
     function check(req) {
       return path === req.url.slice(0, path.length);


### PR DESCRIPTION
Signed-off-by: iifawzi <iifawzie@gmail.com>

Hi, this PR is adding an option to avoid the added trailing slash to the path in the connection as has been done in the engine-client https://github.com/socketio/engine.io-client/pull/694. Resolving https://github.com/socketio/socket.io-client/issues/1550.

### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other


### Other information (e.g. related issues)
https://github.com/socketio/socket.io-client/issues/1550
