### PR TITLE
Removed "Vanilla JS" highlight from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ For more information on the client refer to the
 - **Future proof**
 - **100% Node.JS core style**
   - No API sugar (left for higher level projects)
-  - Written in readable vanilla JavaScript
 
 ## API
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

The documentation states that the codebase is written in "readable vanilla JavaScript".

### New behaviour

It doesn't seem to be the case anymore, therefore, it was removed.

### Other information (e.g. related issues)


