### PR TITLE
Fix unhandled error on HTTP2 upgrade

### DIFF
--- a/lib/server.ts
+++ b/lib/server.ts
@@ -678,6 +678,7 @@ export class Server extends BaseServer {
           setTimeout(function() {
             // @ts-ignore
             if (socket.writable && socket.bytesWritten <= 0) {
+              socket.once('error', e => debug(e));
               return socket.end();
             }
           }, destroyUpgradeTimeout);


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

If you send an HTTP2 upgrade request to the server, we catch the `upgrade` event and close the socket when it turns out not to be a websocket upgrade request. In some cases, this leads to an `error` event, which in turn causes the server to crash.

I created a bare bones project that demonstrates this problem: https://github.com/jonathanneve/socketiotest
Run the server locally (https://github.com/jonathanneve/socketiotest/blob/main/index.js) and then test it using the included python test case (https://github.com/jonathanneve/socketiotest/blob/main/test.py). The server should crash.

This is the same issue as described here: https://github.com/socketio/socket.io/issues/3564 

### New behaviour

The `error` event is caught and (in debug mode) logged to the console. This prevents the error from bubbling up and causing the server to crash.

### Other information (e.g. related issues)

Note that in my situation, the intention is not actually to use HTTP2: I came across the issue by running a vulnerability scanner (Nessus) against my app, which caused it to crash. On closer examination, I found that Nessus was sending an HTTP2 upgrade request. The goal of this PR is not to handle HTTP2, but simply to harden the app, in that a simple upgrade request should not cause a crash.

Note also that I was not able to reproduce the issue using a Node client, as I have less control over the socket options in Node, which is why I used Python for the test case. Using the Nessus scanner (as opposed to my test case), I found that the app crashes only with certain versions of Node (older than v16.16.0), which suggests that the error is contingent on the exact behavior of the socket, which presumably has changed in different Node versions. Either way though, this PR addresses the error in all cases, since it catches any error that occurs while closing the socket.