### PR TITLE
fix NodeNext module resolution compatibility

### DIFF
--- a/lib/engine.io.ts
+++ b/lib/engine.io.ts
@@ -1,10 +1,10 @@
 import { createServer } from "http";
-import { Server, AttachOptions, ServerOptions } from "./server";
+import { Server, AttachOptions, ServerOptions, BaseServer } from "./server";
 import transports from "./transports/index";
 import * as parser from "engine.io-parser";
 
 export { Server, transports, listen, attach, parser };
-export { AttachOptions, ServerOptions } from "./server";
+export { AttachOptions, ServerOptions, BaseServer } from "./server";
 export { uServer } from "./userver";
 export { Socket } from "./socket";
 export { Transport } from "./transport";

--- a/lib/engine.io.ts
+++ b/lib/engine.io.ts
@@ -1,10 +1,10 @@
 import { createServer } from "http";
-import { Server, AttachOptions, ServerOptions, BaseServer } from "./server";
+import { Server, AttachOptions, ServerOptions } from "./server";
 import transports from "./transports/index";
 import * as parser from "engine.io-parser";
 
 export { Server, transports, listen, attach, parser };
-export { AttachOptions, ServerOptions, BaseServer } from "./server";
+export type { AttachOptions, ServerOptions, BaseServer } from "./server";
 export { uServer } from "./userver";
 export { Socket } from "./socket";
 export { Transport } from "./transport";


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behavior

Types are not found when typescript moduleResolution is set to NodeNext, issue https://github.com/socketio/socket.io/issues/4621

### New behavior

Works normally with NodeNext

### Other information (e.g. related issues)

Must be merged together with the socket.io PR https://github.com/socketio/socket.io/pull/4625
