### PR TITLE
feat: add optional downgrade to 409 for request overlap

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ to a single process.
       - `cors` (`Object`): the options that will be forwarded to the cors module. See [there](https://github.com/expressjs/cors#configuration-options) for all available options. Defaults to no CORS allowed.
       - `initialPacket` (`Object`): an optional packet which will be concatenated to the handshake packet emitted by Engine.IO.
       - `allowEIO3` (`Boolean`): whether to support v3 Engine.IO clients (defaults to `false`)
+      - `downgradeOverlapStatus` (`Boolean`): whether to downgrade polling overlap error status from 500 to 409 (defaults to `false`)
 - `close`
     - Closes all clients
     - **Returns** `Server` for chaining

--- a/lib/server.ts
+++ b/lib/server.ts
@@ -117,6 +117,11 @@ export interface ServerOptions {
    * @default false
    */
   allowEIO3?: boolean;
+  /**
+   * whether to use 409 for overlap errors
+   * @default false
+   */
+  downgradeOverlapStatus?: boolean;
 }
 
 export abstract class BaseServer extends EventEmitter {
@@ -152,6 +157,7 @@ export abstract class BaseServer extends EventEmitter {
         },
         cors: false,
         allowEIO3: false,
+        downgradeOverlapStatus: false,
       },
       opts
     );
@@ -511,7 +517,7 @@ export class Server extends BaseServer {
   }
 
   protected createTransport(transportName, req) {
-    return new transports[transportName](req);
+    return new transports[transportName](req, this.opts.downgradeOverlapStatus);
   }
 
   /**

--- a/lib/transports-uws/polling.ts
+++ b/lib/transports-uws/polling.ts
@@ -79,7 +79,9 @@ export class Polling extends Transport {
       debug("request overlap");
       // assert: this.res, '.req and .res should be (un)set together'
       this.onError("overlap from client");
-      this.downgradeOverlapStatus ? res.writeStatus("409 Conflict") : res.writeStatus("500 Internal Server Error");
+      this.downgradeOverlapStatus
+        ? res.writeStatus("409 Conflict")
+        : res.writeStatus("500 Internal Server Error");
       res.end();
       return;
     }
@@ -120,7 +122,9 @@ export class Polling extends Transport {
     if (this.dataReq) {
       // assert: this.dataRes, '.dataReq and .dataRes should be (un)set together'
       this.onError("data request overlap from client");
-      this.downgradeOverlapStatus ? res.writeStatus("409 Conflict") : res.writeStatus("500 Internal Server Error");
+      this.downgradeOverlapStatus
+        ? res.writeStatus("409 Conflict")
+        : res.writeStatus("500 Internal Server Error");
       res.end();
       return;
     }

--- a/lib/transports-uws/polling.ts
+++ b/lib/transports-uws/polling.ts
@@ -22,15 +22,18 @@ export class Polling extends Transport {
 
   private readonly closeTimeout: number;
 
+  private readonly downgradeOverlapStatus: boolean;
+
   /**
    * HTTP polling constructor.
    *
    * @api public.
    */
-  constructor(req) {
+  constructor(req, downgradeOverlapStatus: boolean = false) {
     super(req);
 
     this.closeTimeout = 30 * 1000;
+    this.downgradeOverlapStatus = downgradeOverlapStatus;
   }
 
   /**
@@ -76,7 +79,7 @@ export class Polling extends Transport {
       debug("request overlap");
       // assert: this.res, '.req and .res should be (un)set together'
       this.onError("overlap from client");
-      res.writeStatus("500 Internal Server Error");
+      this.downgradeOverlapStatus ? res.writeStatus("409 Conflict") : res.writeStatus("500 Internal Server Error");
       res.end();
       return;
     }
@@ -117,7 +120,7 @@ export class Polling extends Transport {
     if (this.dataReq) {
       // assert: this.dataRes, '.dataReq and .dataRes should be (un)set together'
       this.onError("data request overlap from client");
-      res.writeStatus("500 Internal Server Error");
+      this.downgradeOverlapStatus ? res.writeStatus("409 Conflict") : res.writeStatus("500 Internal Server Error");
       res.end();
       return;
     }

--- a/lib/transports/index.ts
+++ b/lib/transports/index.ts
@@ -13,11 +13,11 @@ export default {
  * @api private
  */
 
-function polling(req) {
+function polling(req, downgradeOverlapStatus?: boolean) {
   if ("string" === typeof req._query.j) {
-    return new JSONP(req);
+    return new JSONP(req, downgradeOverlapStatus);
   } else {
-    return new XHR(req);
+    return new XHR(req, downgradeOverlapStatus);
   }
 }
 

--- a/lib/transports/polling-jsonp.ts
+++ b/lib/transports/polling-jsonp.ts
@@ -13,8 +13,8 @@ export class JSONP extends Polling {
    *
    * @api public
    */
-  constructor(req) {
-    super(req);
+  constructor(req, downgradeOverlapStatus?: boolean) {
+    super(req, downgradeOverlapStatus);
 
     this.head = "___eio[" + (req._query.j || "").replace(/[^0-9]/g, "") + "](";
     this.foot = ");";

--- a/lib/transports/polling.ts
+++ b/lib/transports/polling.ts
@@ -22,15 +22,18 @@ export class Polling extends Transport {
 
   private readonly closeTimeout: number;
 
+  private readonly downgradeOverlapStatus: boolean;
+
   /**
    * HTTP polling constructor.
    *
    * @api public.
    */
-  constructor(req) {
+  constructor(req, downgradeOverlapStatus: boolean = false) {
     super(req);
 
     this.closeTimeout = 30 * 1000;
+    this.downgradeOverlapStatus = downgradeOverlapStatus;
   }
 
   /**
@@ -75,8 +78,7 @@ export class Polling extends Transport {
       debug("request overlap");
       // assert: this.res, '.req and .res should be (un)set together'
       this.onError("overlap from client");
-      // TODO for the next major release: use an HTTP 400 status code (https://github.com/socketio/engine.io/issues/650)
-      res.writeHead(500);
+      this.downgradeOverlapStatus ? res.writeHead(409) : res.writeHead(500);
       res.end();
       return;
     }
@@ -117,8 +119,7 @@ export class Polling extends Transport {
     if (this.dataReq) {
       // assert: this.dataRes, '.dataReq and .dataRes should be (un)set together'
       this.onError("data request overlap from client");
-      // TODO for the next major release: use an HTTP 400 status code (https://github.com/socketio/engine.io/issues/650)
-      res.writeHead(500);
+      this.downgradeOverlapStatus ? res.writeHead(409) : res.writeHead(500);
       res.end();
       return;
     }


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a new feature

### Current behaviour
If the server encounters a request overlap, an error 500 is sent back to the client. 

### New behaviour
As the error indicates a faulty implementation of the client that opens two long polling requests at the same time and not a problem server-side, we downgrade this error from 500 to 409 Conflict
This new behavior is optional and is controlled by the flag `downgradeOverlapStatus`

### Other information (e.g. related issues)
Related issue : https://github.com/socketio/engine.io/issues/650

