### PR TITLE
Extend support for Express middlewares to include error handling

### DIFF
--- a/lib/server.ts
+++ b/lib/server.ts
@@ -137,7 +137,7 @@ export interface ServerOptions {
 type Middleware = (
   req: IncomingMessage,
   res: ServerResponse,
-  next: () => void
+  next: (err?: any) => void
 ) => void;
 
 export abstract class BaseServer extends EventEmitter {
@@ -335,7 +335,7 @@ export abstract class BaseServer extends EventEmitter {
   protected _applyMiddlewares(
     req: IncomingMessage,
     res: ServerResponse,
-    callback: () => void
+    callback: (err?: any) => void
   ) {
     if (this.middlewares.length === 0) {
       debug("no middleware to apply, skipping");
@@ -344,7 +344,12 @@ export abstract class BaseServer extends EventEmitter {
 
     const apply = (i) => {
       debug("applying middleware n°%d", i + 1);
-      this.middlewares[i](req, res, () => {
+      this.middlewares[i](req, res, (err?: any) => {
+        if (err) {
+          callback(err);
+          return;
+        }
+
         if (i + 1 < this.middlewares.length) {
           apply(i + 1);
         } else {
@@ -655,8 +660,12 @@ export class Server extends BaseServer {
       }
     };
 
-    this._applyMiddlewares(req, res, () => {
-      this.verify(req, false, callback);
+    this._applyMiddlewares(req, res, (err?: any) => {
+      if (err) {
+        callback(Server.errors.BAD_REQUEST, { name: "MIDDLEWARE_FAILURE" });
+      } else {
+        this.verify(req, false, callback);
+      }
     });
   }
 
@@ -673,32 +682,37 @@ export class Server extends BaseServer {
     this.prepare(req);
 
     const res = new WebSocketResponse(req, socket);
-
-    this._applyMiddlewares(req, res as unknown as ServerResponse, () => {
-      this.verify(req, true, (errorCode, errorContext) => {
-        if (errorCode) {
-          this.emit("connection_error", {
-            req,
-            code: errorCode,
-            message: Server.errorMessages[errorCode],
-            context: errorContext,
-          });
-          abortUpgrade(socket, errorCode, errorContext);
-          return;
-        }
-
-        const head = Buffer.from(upgradeHead);
-        upgradeHead = null;
-
-        // some middlewares (like express-session) wait for the writeHead() call to flush their headers
-        // see https://github.com/expressjs/session/blob/1010fadc2f071ddf2add94235d72224cf65159c6/index.js#L220-L244
-        res.writeHead();
-
-        // delegate to ws
-        this.ws.handleUpgrade(req, socket, head, (websocket) => {
-          this.onWebSocket(req, socket, websocket);
+    const callback = (errorCode, errorContext) => {
+      if (errorCode) {
+        this.emit("connection_error", {
+          req,
+          code: errorCode,
+          message: Server.errorMessages[errorCode],
+          context: errorContext,
         });
+        abortUpgrade(socket, errorCode, errorContext);
+        return;
+      }
+
+      const head = Buffer.from(upgradeHead);
+      upgradeHead = null;
+
+      // some middlewares (like express-session) wait for the writeHead() call to flush their headers
+      // see https://github.com/expressjs/session/blob/1010fadc2f071ddf2add94235d72224cf65159c6/index.js#L220-L244
+      res.writeHead();
+
+      // delegate to ws
+      this.ws.handleUpgrade(req, socket, head, (websocket) => {
+        this.onWebSocket(req, socket, websocket);
       });
+    };
+
+    this._applyMiddlewares(req, res as unknown as ServerResponse, (err?: any) => {
+      if (err) {
+        callback(Server.errors.BAD_REQUEST, { name: "MIDDLEWARE_FAILURE" });
+      } else {
+        this.verify(req, true, callback);
+      }
     });
   }
 

--- a/test/middlewares.js
+++ b/test/middlewares.js
@@ -247,4 +247,48 @@ describe("middlewares", () => {
       });
     });
   });
+
+  it("should fail on errors (polling)", (done) => {
+    const engine = listen((port) => {
+      engine.use((req, res, next) => {
+        next(new Error("will always fail"));
+      });
+
+      request
+        .get(`http://localhost:${port}/engine.io/`)
+        .query({ EIO: 4, transport: "polling" })
+        .end((err, res) => {
+          expect(err).to.be.an(Error);
+          expect(res.status).to.eql(400);
+
+          if (engine.httpServer) {
+            engine.httpServer.close();
+          }
+          done();
+        });
+    });
+
+    it("should fail on errors (websocket)", (done) => {
+      const engine = listen((port) => {
+        engine.use((req, res, next) => {
+          next(new Error("will always fail"));
+        });
+
+        engine.on("connection", () => {
+          done(new Error("should not connect"));
+        });
+
+        const socket = new WebSocket(
+          `ws://localhost:${port}/engine.io/?EIO=4&transport=websocket`
+        );
+
+        socket.addEventListener("error", () => {
+          if (engine.httpServer) {
+            engine.httpServer.close();
+          }
+          done();
+        })
+      });
+    })
+  });
 });


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
Currently, the next function passed to express-style middlewares does not take into account any potential errors handed to it. If a express-style middleware fails, the connection and all following middlewares will still be executed and a connection will be established successfully.

### New behaviour
If any value other than undefined is passed to the next function, all further middlewares will not be executed. The socket will be closed, receiving an error "Bad Request" as if the verify function in server.ts had failed. This behaviour is more consistent with how express handles errors emerging in its middleware (see [here](https://expressjs.com/en/guide/error-handling.html) for details).

### Other information (e.g. related issues)

I mostly wrote the code for this pull request to see if there was any obvious obstacles with handling errors as described above. I had recently found myself in a situation where I wanted to verify CSRF tokens during connection establishment but was unable to fail connection attempts from within middlewares.

Obviously, there may be things I have missed or possibly even good reasons to not allow any such error handling at all. If there are, please dismiss this pull request. Additionally, it may be more advantageous to return a custom, new type of error or possibly to not return a 'middleware failure' token in the error context out of security considerations.

I have added two tests for failing middlewares (both polling and websockets).


Thank you for your time!

