### PR TITLE
Make clientsCount public

### DIFF
--- a/lib/server.ts
+++ b/lib/server.ts
@@ -144,7 +144,7 @@ export abstract class BaseServer extends EventEmitter {
   public opts: ServerOptions;
 
   protected clients: any;
-  private clientsCount: number;
+  public clientsCount: number;
   protected middlewares: Middleware[] = [];
 
   /**


### PR DESCRIPTION
Fixes #672


### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

`clientsCount` is private which it shouldn't be as it is explicitly mentioned as something you can use in both the README:
https://github.com/socketio/engine.io/blob/535b068670848f6a3193528582484826a858d680/README.md?plain=1#L245
and the website: https://socket.io/docs/v4/server-instance/#serverengine


### New behaviour

`clientsCount` is public.

### Other information (e.g. related issues)


