### PR TITLE
Update userver.ts to work with alien mode

### DIFF
--- a/lib/userver.ts
+++ b/lib/userver.ts
@@ -155,7 +155,7 @@ export class uServer extends BaseServer {
 
   private handleUpgrade(
     res: HttpResponse,
-    req: HttpRequest & { res: any; _query: any, headers: any },
+    req: HttpRequest & { res: any; _query: any; headers: any },
     context
   ) {
     debug("on upgrade");

--- a/lib/userver.ts
+++ b/lib/userver.ts
@@ -214,9 +214,9 @@ export class uServer extends BaseServer {
         {
           transport,
         },
-        req.getHeader("sec-websocket-key"),
-        req.getHeader("sec-websocket-protocol"),
-        req.getHeader("sec-websocket-extensions"),
+        req.headers["sec-websocket-key"],
+        req.headers["sec-websocket-protocol"],
+        req.headers["sec-websocket-extensions"],
         context
       );
     };

--- a/lib/userver.ts
+++ b/lib/userver.ts
@@ -155,7 +155,7 @@ export class uServer extends BaseServer {
 
   private handleUpgrade(
     res: HttpResponse,
-    req: HttpRequest & { res: any; _query: any },
+    req: HttpRequest & { res: any; _query: any, headers: any },
     context
   ) {
     debug("on upgrade");


### PR DESCRIPTION
in alien mode you can not access getHeader and we need to access a cached version of the headers as this is forbidden  by uws


### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour


### New behaviour


### Other information (e.g. related issues)


