### PR TITLE
fix: prevent crash when accessing TextDecoder

### DIFF
--- a/lib/server.ts
+++ b/lib/server.ts
@@ -16,6 +16,7 @@ import type { CookieSerializeOptions } from "cookie";
 import type { CorsOptions, CorsOptionsDelegate } from "cors";
 import type { Duplex } from "stream";
 import { WebTransport } from "./transports/webtransport";
+import { TextDecoder } from "util";
 
 const debug = debugModule("engine");
 


### PR DESCRIPTION
This bug was introduced in [1] and included in release 6.5.0.

[1] 123b68c


### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
The TextDecoder object was never imported before being used. This is the cause of https://github.com/socketio/engine.io/issues/683.

### New behaviour
Adding the dependency stops the crash from occuring.

### Other information (e.g. related issues)


