### PR TITLE
fix: improve compat with ts in node16/bundler mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "./build/engine.io.js",
   "types": "./build/engine.io.d.ts",
   "exports": {
+    "types": "./build/engine.io.d.ts",
     "import": "./wrapper.mjs",
     "require": "./build/engine.io.js"
   },


### PR DESCRIPTION
When using the newer resolution and module modes of typescript, it could pick up `./wrapper.mjs`, which does not have a `.d.ts` file next to it.

Added the `"types"` condition to ensure imports to `"engine.io"` always get a type, no matter if they are sourced in commonjs or esm.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
Cannot find types for package in these newer modes.

### New behaviour
Works as expected. Types load.

### Other information (e.g. related issues)
Change is backward compatible.