### PR TITLE
Make Socket.request writable to allow setting it to `null` as suggested in the documentation

### DIFF
--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -17,7 +17,7 @@ type ReadyState = "opening" | "open" | "closing" | "closed";
 export class Socket extends EventEmitter {
   public readonly protocol: number;
   // TODO for the next major release: do not keep the reference to the first HTTP request, as it stays in memory
-  public readonly request: IncomingMessage;
+  public request: IncomingMessage;
   public readonly remoteAddress: string;
 
   public _readyState: ReadyState = "opening";


### PR DESCRIPTION
Fixes #696.

I would have added a test that confirms the issue is fixed, but since this is a TypeScript-only issue and the tests are not yet converted to TypeScript it seems difficult.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other
