### PR TITLE
Fix `websocket` and `webtransport` multipart callbacks (#698)

### DIFF
--- a/lib/transport.ts
+++ b/lib/transport.ts
@@ -138,11 +138,6 @@ export abstract class Transport extends EventEmitter {
   }
 
   /**
-   * Advertise framing support.
-   */
-  abstract get supportsFraming();
-
-  /**
    * The name of the transport.
    */
   abstract get name();

--- a/lib/transports-uws/polling.ts
+++ b/lib/transports-uws/polling.ts
@@ -42,10 +42,6 @@ export class Polling extends Transport {
     return "polling";
   }
 
-  get supportsFraming() {
-    return false;
-  }
-
   /**
    * Overrides onRequest.
    *

--- a/lib/transports-uws/websocket.ts
+++ b/lib/transports-uws/websocket.ts
@@ -38,15 +38,6 @@ export class WebSocket extends Transport {
   }
 
   /**
-   * Advertise framing support.
-   *
-   * @api public
-   */
-  get supportsFraming() {
-    return false;
-  }
-
-  /**
    * Writes a packet payload.
    *
    * @param {Array} packets

--- a/lib/transports-uws/websocket.ts
+++ b/lib/transports-uws/websocket.ts
@@ -43,7 +43,7 @@ export class WebSocket extends Transport {
    * @api public
    */
   get supportsFraming() {
-    return true;
+    return false;
   }
 
   /**

--- a/lib/transports/polling.ts
+++ b/lib/transports/polling.ts
@@ -42,10 +42,6 @@ export class Polling extends Transport {
     return "polling";
   }
 
-  get supportsFraming() {
-    return false;
-  }
-
   /**
    * Overrides onRequest.
    *

--- a/lib/transports/websocket.ts
+++ b/lib/transports/websocket.ts
@@ -51,7 +51,7 @@ export class WebSocket extends Transport {
    * @api public
    */
   get supportsFraming() {
-    return true;
+    return false;
   }
 
   /**

--- a/lib/transports/websocket.ts
+++ b/lib/transports/websocket.ts
@@ -46,15 +46,6 @@ export class WebSocket extends Transport {
   }
 
   /**
-   * Advertise framing support.
-   *
-   * @api public
-   */
-  get supportsFraming() {
-    return false;
-  }
-
-  /**
    * Writes a packet payload.
    *
    * @param {Array} packets

--- a/lib/transports/webtransport.ts
+++ b/lib/transports/webtransport.ts
@@ -45,7 +45,7 @@ export class WebTransport extends Transport {
   }
 
   get supportsFraming() {
-    return true;
+    return false;
   }
 
   async send(packets) {

--- a/lib/transports/webtransport.ts
+++ b/lib/transports/webtransport.ts
@@ -44,10 +44,6 @@ export class WebTransport extends Transport {
     return "webtransport";
   }
 
-  get supportsFraming() {
-    return false;
-  }
-
   async send(packets) {
     this.writable = false;
 

--- a/test/server.js
+++ b/test/server.js
@@ -2759,13 +2759,23 @@ describe("server", () => {
         });
       });
 
-      it("should execute in multipart packet", (done) => {
+      it("should execute in multipart packet (websocket)", (done) => {
         const engine = listen((port) => {
-          const socket = new ClientSocket(`ws://localhost:${port}`);
+          const socket = new ClientSocket(`ws://localhost:${port}`, {
+            transports: ["websocket"],
+          });
           let i = 0;
           let j = 0;
 
           engine.on("connection", (conn) => {
+            conn.send("d", (transport) => {
+              i++;
+            });
+
+            conn.send("c", (transport) => {
+              i++;
+            });
+
             conn.send("b", (transport) => {
               i++;
             });

--- a/test/webtransport.mjs
+++ b/test/webtransport.mjs
@@ -373,6 +373,21 @@ describe("WebTransport", () => {
     });
   });
 
+  it("should invoke send callbacks (server to client)", (done) => {
+    setup({}, async ({ engine, h3Server, socket, reader }) => {
+      const messageCount = 4;
+      let receivedCallbacks = 0;
+
+      for (let i = 0; i < messageCount; i++) {
+        socket.send("hello", () => {
+          if (++receivedCallbacks === messageCount) {
+            success(engine, h3Server, done);
+          }
+        });
+      }
+    });
+  });
+
   it("should send some binary data (client to server)", (done) => {
     setup({}, async ({ engine, h3Server, socket, writer }) => {
       socket.on("data", (data) => {


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

When using the `websocket` transport, some `send` callbacks are not called. See #698, and the tests added in the first commit of this PR. The `webtransport` transport was also found to have the same bug when testing.

### New behaviour

All `send` callbacks are now called.

Also, the type for the `callback` argument to `send()` was enriched to reflect the fact that the transport is passed (as it always has been) as its first argument. This does change the types visible publicly, but TypeScript type compatibility rules should make this a non-breaking change (i.e. it's still OK to pass a callback expecting no arguments).

### Other information

The bug was caused by the `websocket` transport (and `webtransport` as well) having its `supportsFraming` property set to `true`, despite having been changed in #618 to emit a single `drain` event for each batch of messages written to the transport like the `polling` transport always did. Note that although #618 is partially reverted in https://github.com/socketio/engine.io/commit/a65a047526401bebaa113a8c70d03f5d963eaa54, the new `drain` event behavior is preserved as called out in that commit's message.

The `supportsFraming` attribute was introduced in #130 (amended by #132) as a way to distinguish transports that emit one `drain` per message from those that emit one `drain` per batch. Since the delivery of `send` callbacks depends on matching `drain` events with `transport.send` calls, that distinction is vital to correct behavior.

However, now that all transports have converged to "one `drain` per batch" behavior, this `supportsFraming` property can be retired (and the code for calling callbacks simplified), and this is the refactoring that the last commit of this PR proposes. This is technically a breaking change since `supportsFraming` was exposed in the TypeScript types of `engine.io`, but as far as I can tell it was never documented.

